### PR TITLE
chore(toolchain): bump Bun version policy in packageManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "1-tok",
   "private": true,
-  "packageManager": "bun@1.1.8",
+  "packageManager": "bun@1.2.22",
   "workspaces": [
     "apps/*",
     "packages/*"


### PR DESCRIPTION
## Summary\n- update root packageManager from bun@1.1.8 to bun@1.2.22\n- align repository Bun baseline to a maintained release\n\nFixes #3