### PR TITLE
chore(lint): add golangci-lint baseline config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,13 @@
+run:
+  timeout: 5m
+  tests: true
+linters:
+  enable:
+    - govet
+    - staticcheck
+    - ineffassign
+    - errcheck
+    - gosimple
+    - unused
+issues:
+  exclude-use-default: false

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:web": "bun --cwd apps/web test",
     "test:go": "CGO_ENABLED=0 go test ./...",
     "test:contracts": "bun --cwd packages/contracts test",
-    "test:integration": "./scripts/ci/run-integration-suite.sh"
+    "test:integration": "./scripts/ci/run-integration-suite.sh",
+    "lint:go": "golangci-lint run ./..."
   }
 }


### PR DESCRIPTION
## Summary
- add `.golangci.yml` baseline configuration
- add `bun run lint:go` script for local/CI integration

Fixes #4