### PR TITLE
docs(env): add .env.example and environment contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,32 @@
+# Core service URLs
+IAM_UPSTREAM=http://127.0.0.1:8081
+API_GATEWAY_UPSTREAM=http://127.0.0.1:8080
+EXECUTION_BASE_URL=http://127.0.0.1:8085
+SETTLEMENT_BASE_URL=http://127.0.0.1:8083
+
+# Datastores
+DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/one_tok?sslmode=disable
+REDIS_URL=redis://127.0.0.1:6379/0
+NATS_URL=nats://127.0.0.1:4222
+
+# Service tokens
+API_GATEWAY_EXECUTION_TOKEN=replace-me
+EXECUTION_EVENT_TOKEN=replace-me
+EXECUTION_GATEWAY_TOKEN=replace-me
+SETTLEMENT_SERVICE_TOKEN=replace-me
+
+# Fiber / Carrier dependencies
+FIBER_RPC_URL=https://fiber.example/rpc
+FIBER_APP_ID=app_live
+FIBER_HMAC_SECRET=replace-me
+CARRIER_GATEWAY_URL=https://carrier.example
+CARRIER_GATEWAY_API_TOKEN=replace-me
+
+# Observability
+SENTRY_DSN=
+SENTRY_ENVIRONMENT=development
+SENTRY_RELEASE=local
+
+# Runtime flags
+ONE_TOK_REQUIRE_EXTERNALS=false
+RATE_LIMIT_ENFORCE=false

--- a/docs/env.md
+++ b/docs/env.md
@@ -1,0 +1,25 @@
+# Environment Contract
+
+This file documents common environment variables used by 1-tok services.
+
+## Required in most local workflows
+- `DATABASE_URL`
+- `REDIS_URL` (required when `RATE_LIMIT_ENFORCE=true`)
+- `NATS_URL`
+
+## Service auth tokens
+- `API_GATEWAY_EXECUTION_TOKEN` (or `API_GATEWAY_EXECUTION_TOKENS`)
+- `EXECUTION_EVENT_TOKEN` (or `EXECUTION_EVENT_TOKENS`)
+- `EXECUTION_GATEWAY_TOKEN` (or `EXECUTION_GATEWAY_TOKENS`)
+- `SETTLEMENT_SERVICE_TOKEN` (or `SETTLEMENT_SERVICE_TOKENS`)
+
+## External dependencies (when `ONE_TOK_REQUIRE_EXTERNALS=true`)
+- `IAM_UPSTREAM`
+- `API_GATEWAY_UPSTREAM`
+- `FIBER_RPC_URL`, `FIBER_APP_ID`, `FIBER_HMAC_SECRET`
+- `CARRIER_GATEWAY_URL`, `CARRIER_GATEWAY_API_TOKEN`
+
+## Observability
+- `SENTRY_DSN`
+- `SENTRY_ENVIRONMENT`
+- `SENTRY_RELEASE`


### PR DESCRIPTION
## Summary
- add root `.env.example` for local bootstrap
- add `docs/env.md` describing required/optional variables by mode

Fixes #7