### PR TITLE
docs(ops): define health/readiness endpoint contract

### DIFF
--- a/docs/health-readiness.md
+++ b/docs/health-readiness.md
@@ -5,13 +5,22 @@ This document standardizes endpoint semantics across HTTP services.
 ## Endpoints
 
 - `GET /healthz`
-  - Liveness only.
-  - Returns `200` when process can serve HTTP.
+  - Liveness only. This probe should not check dependencies.
+  - Returns `200` when the process's HTTP server is responsive.
 
 - `GET /readyz`
   - Readiness gate for dependencies.
   - Returns `200` when the service is ready for traffic.
-  - Returns `503` when required dependencies are unavailable.
+  - Returns `503` when required dependencies are unavailable. The response body SHOULD provide details on dependency status, for example:
+    ```json
+    {
+      "status": "unhealthy",
+      "checks": {
+        "database": "up",
+        "redis": "down"
+      }
+    }
+    ```
 
 ## Adoption plan
 


### PR DESCRIPTION
## Summary
- add service health/readiness contract document
- define semantics for `/healthz` and `/readyz`
- include service adoption checklist

Fixes #6