### PR TITLE
ci: add concurrency cancellation for duplicate branch runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit:
     name: Unit And Coverage


### PR DESCRIPTION
## Summary
- add workflow-level concurrency group to CI
- cancel older in-progress runs on same ref

Fixes #2