### PR TITLE
security(postgres): validate sequence name to prevent SQL injection

### DIFF
--- a/internal/store/postgres/repository.go
+++ b/internal/store/postgres/repository.go
@@ -307,11 +307,29 @@ type nextIDQueryer interface {
 }
 
 func nextIDScanner(db nextIDQueryer, sequenceName, prefix string) (string, error) {
+	if !validSequenceName(sequenceName) {
+		return "", fmt.Errorf("invalid sequence name: %q", sequenceName)
+	}
 	var value int64
 	if err := db.QueryRow(fmt.Sprintf(`SELECT nextval('%s')`, sequenceName)).Scan(&value); err != nil {
 		return "", err
 	}
 	return fmt.Sprintf("%s_%d", prefix, value), nil
+}
+
+// validSequenceName checks that a sequence name contains only lowercase letters,
+// digits, and underscores. This prevents SQL injection when the name is
+// interpolated into a query via fmt.Sprintf.
+func validSequenceName(name string) bool {
+	if len(name) == 0 || len(name) > 63 {
+		return false
+	}
+	for _, c := range name {
+		if !((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_') {
+			return false
+		}
+	}
+	return true
 }
 
 func decodeOrder(payload []byte) (*core.Order, error) {

--- a/internal/store/postgres/sequence_name_test.go
+++ b/internal/store/postgres/sequence_name_test.go
@@ -1,0 +1,37 @@
+package postgres
+
+import "testing"
+
+func TestValidSequenceName(t *testing.T) {
+	valid := []string{
+		"order_seq",
+		"rfq_seq",
+		"bid_seq",
+		"message_seq",
+		"dispute_seq",
+		"user_seq",
+		"organization_seq",
+		"iam_session_seq",
+		"settlement_funding_record_seq",
+	}
+	for _, name := range valid {
+		if !validSequenceName(name) {
+			t.Errorf("expected %q to be valid", name)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"ORDER_SEQ",
+		"order seq",
+		"order-seq",
+		"'; DROP TABLE users; --",
+		"order_seq\x00",
+		"order.seq",
+	}
+	for _, name := range invalid {
+		if validSequenceName(name) {
+			t.Errorf("expected %q to be invalid", name)
+		}
+	}
+}


### PR DESCRIPTION
Adds `validSequenceName()` guard to `nextIDScanner()` — rejects any sequence name containing characters outside `[a-z0-9_]` or exceeding 63 chars (Postgres identifier limit).

All current callers pass hardcoded literals so behavior is unchanged, but this closes a latent injection vector if a future caller passes user-controlled input.

Includes test coverage for valid and invalid sequence names.

Fixes #31