### PR TITLE
security: add request body size limits to all HTTP services

### DIFF
--- a/cmd/api-gateway/main.go
+++ b/cmd/api-gateway/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/chenyu/1-tok/internal/bootstrap"
 	"github.com/chenyu/1-tok/internal/gateway"
+	"github.com/chenyu/1-tok/internal/httputil"
 	"github.com/chenyu/1-tok/internal/observability"
 )
 
@@ -30,7 +31,8 @@ func main() {
 	}()
 
 	log.Printf("api-gateway listening on %s", addr)
-	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("api-gateway", gateway.NewServerWithApp(app))))
+	handler := httputil.LimitBody(gateway.NewServerWithApp(app), 0)
+	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("api-gateway", handler)))
 }
 
 func envOrDefault(key, fallback string) string {

--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/chenyu/1-tok/internal/httputil"
 	"github.com/chenyu/1-tok/internal/observability"
 	"github.com/chenyu/1-tok/internal/services/execution"
 )
@@ -19,7 +20,8 @@ func main() {
 	defer shutdown(2 * time.Second)
 
 	log.Printf("execution listening on %s", addr)
-	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("execution", execution.NewServer())))
+	handler := httputil.LimitBody(execution.NewServer(), 0)
+	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("execution", handler)))
 }
 
 func envOrDefault(key, fallback string) string {

--- a/cmd/fiber-adapter/main.go
+++ b/cmd/fiber-adapter/main.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/chenyu/1-tok/internal/fiberadapter"
+	"github.com/chenyu/1-tok/internal/httputil"
 	"github.com/chenyu/1-tok/internal/observability"
 )
 
@@ -19,7 +20,8 @@ func main() {
 	defer shutdown(2 * time.Second)
 
 	log.Printf("fiber-adapter listening on %s", addr)
-	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("fiber-adapter", fiberadapter.NewServer())))
+	handler := httputil.LimitBody(fiberadapter.NewServer(), 0)
+	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("fiber-adapter", handler)))
 }
 
 func envOrDefault(key, fallback string) string {

--- a/cmd/iam/main.go
+++ b/cmd/iam/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/chenyu/1-tok/internal/httputil"
 	"github.com/chenyu/1-tok/internal/observability"
 	"github.com/chenyu/1-tok/internal/services/iam"
 )
@@ -19,7 +20,8 @@ func main() {
 	defer shutdown(2 * time.Second)
 
 	log.Printf("iam listening on %s", addr)
-	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("iam", iam.NewServer())))
+	handler := httputil.LimitBody(iam.NewServer(), 0)
+	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("iam", handler)))
 }
 
 func envOrDefault(key, fallback string) string {

--- a/cmd/marketplace/main.go
+++ b/cmd/marketplace/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/chenyu/1-tok/internal/httputil"
 	"github.com/chenyu/1-tok/internal/observability"
 	"github.com/chenyu/1-tok/internal/services/marketplace"
 )
@@ -19,7 +20,8 @@ func main() {
 	defer shutdown(2 * time.Second)
 
 	log.Printf("marketplace listening on %s", addr)
-	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("marketplace", marketplace.NewServer())))
+	handler := httputil.LimitBody(marketplace.NewServer(), 0)
+	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("marketplace", handler)))
 }
 
 func envOrDefault(key, fallback string) string {

--- a/cmd/notification/main.go
+++ b/cmd/notification/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/chenyu/1-tok/internal/httputil"
 	"github.com/chenyu/1-tok/internal/observability"
 	"github.com/chenyu/1-tok/internal/services/notification"
 )
@@ -19,7 +20,8 @@ func main() {
 	defer shutdown(2 * time.Second)
 
 	log.Printf("notification listening on %s", addr)
-	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("notification", notification.NewServer())))
+	handler := httputil.LimitBody(notification.NewServer(), 0)
+	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("notification", handler)))
 }
 
 func envOrDefault(key, fallback string) string {

--- a/cmd/risk/main.go
+++ b/cmd/risk/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/chenyu/1-tok/internal/httputil"
 	"github.com/chenyu/1-tok/internal/observability"
 	"github.com/chenyu/1-tok/internal/services/risk"
 )
@@ -19,7 +20,8 @@ func main() {
 	defer shutdown(2 * time.Second)
 
 	log.Printf("risk listening on %s", addr)
-	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("risk", risk.NewServer())))
+	handler := httputil.LimitBody(risk.NewServer(), 0)
+	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("risk", handler)))
 }
 
 func envOrDefault(key, fallback string) string {

--- a/cmd/settlement/main.go
+++ b/cmd/settlement/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/chenyu/1-tok/internal/httputil"
 	"github.com/chenyu/1-tok/internal/observability"
 	"github.com/chenyu/1-tok/internal/services/settlement"
 )
@@ -19,7 +20,8 @@ func main() {
 	defer shutdown(2 * time.Second)
 
 	log.Printf("settlement listening on %s", addr)
-	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("settlement", settlement.NewServer())))
+	handler := httputil.LimitBody(settlement.NewServer(), 0)
+	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("settlement", handler)))
 }
 
 func envOrDefault(key, fallback string) string {

--- a/internal/httputil/request.go
+++ b/internal/httputil/request.go
@@ -1,0 +1,19 @@
+package httputil
+
+import "net/http"
+
+// DefaultMaxBodyBytes is the maximum request body size (1 MB).
+// Most API endpoints expect payloads under 10 KB.
+const DefaultMaxBodyBytes int64 = 1 << 20
+
+// LimitBody wraps r.Body with http.MaxBytesReader to cap the request
+// body at maxBytes. Pass 0 to use DefaultMaxBodyBytes.
+func LimitBody(next http.Handler, maxBytes int64) http.Handler {
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxBodyBytes
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/httputil/request_test.go
+++ b/internal/httputil/request_test.go
@@ -1,0 +1,65 @@
+package httputil
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestLimitBody_AllowsSmallPayload(t *testing.T) {
+	handler := LimitBody(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("unexpected read error: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}), 1024)
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("hello"))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if rec.Body.String() != "hello" {
+		t.Fatalf("expected body 'hello', got %q", rec.Body.String())
+	}
+}
+
+func TestLimitBody_RejectsOversizedPayload(t *testing.T) {
+	handler := LimitBody(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "payload too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}), 10) // 10 byte limit
+
+	bigPayload := strings.Repeat("x", 100)
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(bigPayload))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d", rec.Code)
+	}
+}
+
+func TestLimitBody_DefaultMaxBytes(t *testing.T) {
+	handler := LimitBody(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), 0) // should use default
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("ok"))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}


### PR DESCRIPTION
Introduces `internal/httputil.LimitBody` middleware wrapping `http.MaxBytesReader` with a default **1 MB** cap.

Applied to all 8 production entrypoints:
- api-gateway, settlement, execution, iam
- marketplace, notification, risk, fiber-adapter

Mock services are intentionally excluded (test/dev only).

Includes 3 test cases: small payload allowed, oversized rejected (413), default fallback.

Fixes #33