### PR TITLE
security(fiberadapter): add HMAC signature verification for incoming RPC requests

### DIFF
--- a/internal/fiberadapter/hmac_test_helpers_test.go
+++ b/internal/fiberadapter/hmac_test_helpers_test.go
@@ -1,0 +1,44 @@
+package fiberadapter
+
+import "context"
+
+type stubRPCNode struct {
+	invoiceAddress string
+	invoiceStatus  string
+	sendPaymentID  string
+	err            error
+}
+
+func (n *stubRPCNode) CreateInvoice(_ context.Context, _, _ string) (string, error) {
+	if n.err != nil {
+		return "", n.err
+	}
+	if n.invoiceAddress != "" {
+		return n.invoiceAddress, nil
+	}
+	return "inv_stub_1", nil
+}
+
+func (n *stubRPCNode) GetInvoiceStatus(_ context.Context, _ string) (string, error) {
+	if n.err != nil {
+		return "", n.err
+	}
+	if n.invoiceStatus != "" {
+		return n.invoiceStatus, nil
+	}
+	return "UNPAID", nil
+}
+
+func (n *stubRPCNode) ValidatePaymentRequest(_ context.Context, _ string) error {
+	return n.err
+}
+
+func (n *stubRPCNode) SendPayment(_ context.Context, _, _, _, _ string) (string, error) {
+	if n.err != nil {
+		return "", n.err
+	}
+	if n.sendPaymentID != "" {
+		return n.sendPaymentID, nil
+	}
+	return "tx_stub_1", nil
+}

--- a/internal/fiberadapter/server.go
+++ b/internal/fiberadapter/server.go
@@ -2,12 +2,14 @@ package fiberadapter
 
 import (
 	"context"
+	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -23,11 +25,15 @@ type Options struct {
 	PayerRPCURL   string
 	InvoiceNode   rawNode
 	PayerNode     rawNode
+	AppID         string
+	HMACSecret    string
 }
 
 type Server struct {
 	invoiceNode rawNode
 	payerNode   rawNode
+	appID       string
+	hmacSecret  string
 
 	mu              sync.Mutex
 	tipSeq          int
@@ -57,7 +63,10 @@ type rawNode interface {
 }
 
 func NewServer() *Server {
-	return NewServerWithOptions(Options{})
+	return NewServerWithOptions(Options{
+		AppID:      strings.TrimSpace(os.Getenv("FIBER_APP_ID")),
+		HMACSecret: strings.TrimSpace(os.Getenv("FIBER_HMAC_SECRET")),
+	})
 }
 
 func NewServerWithOptions(options Options) *Server {
@@ -91,6 +100,8 @@ func NewServerWithOptions(options Options) *Server {
 	return &Server{
 		invoiceNode:     options.InvoiceNode,
 		payerNode:       options.PayerNode,
+		appID:           strings.TrimSpace(options.AppID),
+		hmacSecret:      strings.TrimSpace(options.HMACSecret),
 		tips:            map[string]*tipRecord{},
 		withdrawalsByID: map[string]*fiberclient.WithdrawalStatusItem{},
 	}
@@ -106,13 +117,25 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Read body into memory so we can verify the HMAC signature.
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeRPCError(w, nil, -32700, "failed to read request body")
+		return
+	}
+
+	if err := s.verifyHMAC(r, body); err != nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": err.Error()})
+		return
+	}
+
 	var payload struct {
 		JSONRPC string          `json:"jsonrpc"`
 		ID      any             `json:"id"`
 		Method  string          `json:"method"`
 		Params  json.RawMessage `json:"params"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+	if err := json.Unmarshal(body, &payload); err != nil {
 		writeRPCError(w, payload.ID, -32700, "invalid json")
 		return
 	}
@@ -572,6 +595,42 @@ func writeJSON(w http.ResponseWriter, status int, payload any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(payload)
+}
+
+// verifyHMAC checks the x-signature header against the request body using the
+// shared HMAC secret. When no secret is configured, verification is skipped
+// (backward compatible with existing deployments that haven't set FIBER_HMAC_SECRET).
+//
+// The signature format matches the Fiber client: HMAC-SHA256(secret, ts + "." + nonce + "." + body).
+func (s *Server) verifyHMAC(r *http.Request, body []byte) error {
+	if s.hmacSecret == "" {
+		return nil // auth not configured — allow all (backward compat)
+	}
+
+	appID := strings.TrimSpace(r.Header.Get("x-app-id"))
+	ts := strings.TrimSpace(r.Header.Get("x-ts"))
+	nonce := strings.TrimSpace(r.Header.Get("x-nonce"))
+	signature := strings.TrimSpace(r.Header.Get("x-signature"))
+
+	if signature == "" || ts == "" || nonce == "" {
+		return errors.New("missing signature headers")
+	}
+	if s.appID != "" && appID != s.appID {
+		return errors.New("app id mismatch")
+	}
+
+	mac := hmac.New(sha256.New, []byte(s.hmacSecret))
+	_, _ = mac.Write([]byte(ts))
+	_, _ = mac.Write([]byte("."))
+	_, _ = mac.Write([]byte(nonce))
+	_, _ = mac.Write([]byte("."))
+	_, _ = mac.Write(body)
+	expected := hex.EncodeToString(mac.Sum(nil))
+
+	if !hmac.Equal([]byte(expected), []byte(signature)) {
+		return errors.New("invalid signature")
+	}
+	return nil
 }
 
 func writeRPCResult(w http.ResponseWriter, id any, result any) {

--- a/internal/fiberadapter/server_test.go
+++ b/internal/fiberadapter/server_test.go
@@ -1,8 +1,11 @@
 package fiberadapter
 
 import (
-	"context"
 	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io"
@@ -381,4 +384,99 @@ func (rejectingRawNode) ValidatePaymentRequest(context.Context, string) error {
 
 func (rejectingRawNode) SendPayment(context.Context, string, string, string, string) (string, error) {
 	return "", errors.New("unexpected call")
+}
+
+func TestHMACVerification_NoSecretAllowsAll(t *testing.T) {
+	server := NewServerWithOptions(Options{
+		InvoiceNode: &stubRPCNode{},
+		PayerNode:   &stubRPCNode{},
+		// no AppID or HMACSecret
+	})
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tip.status","params":{"invoice":"inv_1"}}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+
+	// should not be 401 — HMAC is disabled
+	if rec.Code == http.StatusUnauthorized {
+		t.Fatalf("expected non-401 when HMAC is not configured, got %d", rec.Code)
+	}
+}
+
+func TestHMACVerification_RejectsMissingSignature(t *testing.T) {
+	server := NewServerWithOptions(Options{
+		InvoiceNode: &stubRPCNode{},
+		PayerNode:   &stubRPCNode{},
+		AppID:       "test-app",
+		HMACSecret:  "test-secret",
+	})
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tip.status","params":{"invoice":"inv_1"}}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	// no x-signature headers
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHMACVerification_RejectsInvalidSignature(t *testing.T) {
+	server := NewServerWithOptions(Options{
+		InvoiceNode: &stubRPCNode{},
+		PayerNode:   &stubRPCNode{},
+		AppID:       "test-app",
+		HMACSecret:  "test-secret",
+	})
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tip.status","params":{"invoice":"inv_1"}}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("x-app-id", "test-app")
+	req.Header.Set("x-ts", "1234567890")
+	req.Header.Set("x-nonce", "abc123")
+	req.Header.Set("x-signature", "badsignature")
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHMACVerification_AcceptsValidSignature(t *testing.T) {
+	secret := "test-secret"
+	server := NewServerWithOptions(Options{
+		InvoiceNode: &stubRPCNode{invoiceStatus: "UNPAID"},
+		PayerNode:   &stubRPCNode{},
+		AppID:       "test-app",
+		HMACSecret:  secret,
+	})
+
+	body := []byte(`{"jsonrpc":"2.0","id":1,"method":"tip.status","params":{"invoice":"inv_1"}}`)
+	ts := "1234567890"
+	nonce := "abc123"
+
+	// compute valid HMAC-SHA256 signature matching fiber client format
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(ts))
+	mac.Write([]byte("."))
+	mac.Write([]byte(nonce))
+	mac.Write([]byte("."))
+	mac.Write(body)
+	signature := hex.EncodeToString(mac.Sum(nil))
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	req.Header.Set("x-app-id", "test-app")
+	req.Header.Set("x-ts", ts)
+	req.Header.Set("x-nonce", nonce)
+	req.Header.Set("x-signature", signature)
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+
+	// should not be 401
+	if rec.Code == http.StatusUnauthorized {
+		t.Fatalf("expected non-401 with valid signature, got %d body=%s", rec.Code, rec.Body.String())
+	}
 }


### PR DESCRIPTION
The Fiber client signs every outgoing request with HMAC-SHA256 (`x-signature`, `x-ts`, `x-nonce`, `x-app-id`), but the adapter server previously accepted all POST requests without verification.

**Changes:**
- Add `AppID` and `HMACSecret` fields to `Options` / `Server`
- Read `FIBER_APP_ID` and `FIBER_HMAC_SECRET` from env in `NewServer()`
- Read body into memory, verify HMAC before JSON decode
- Return 401 on missing/invalid signature

**Backward compatible:** when `FIBER_HMAC_SECRET` is not set, verification is skipped.

**Tests:** 4 cases — no-secret pass-through, missing headers, invalid signature, valid signature. All existing tests pass.

Fixes #38