### PR TITLE
fix: add graceful HTTP shutdown to all service entrypoints

### DIFF
--- a/cmd/api-gateway/main.go
+++ b/cmd/api-gateway/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"log"
-	"net/http"
 	"os"
 	"time"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/chenyu/1-tok/internal/gateway"
 	"github.com/chenyu/1-tok/internal/httputil"
 	"github.com/chenyu/1-tok/internal/observability"
+	"github.com/chenyu/1-tok/internal/server"
 )
 
 func main() {
@@ -32,7 +32,9 @@ func main() {
 
 	log.Printf("api-gateway listening on %s", addr)
 	handler := httputil.LimitBody(gateway.NewServerWithApp(app), 0)
-	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("api-gateway", handler)))
+	if err := server.Run(addr, observability.WrapHTTP("api-gateway", handler), 0); err != nil {
+		log.Fatal(err)
+	}
 }
 
 func envOrDefault(key, fallback string) string {

--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"log"
-	"net/http"
 	"os"
 	"time"
 
 	"github.com/chenyu/1-tok/internal/httputil"
+	"github.com/chenyu/1-tok/internal/server"
 	"github.com/chenyu/1-tok/internal/observability"
 	"github.com/chenyu/1-tok/internal/services/execution"
 )
@@ -21,7 +21,9 @@ func main() {
 
 	log.Printf("execution listening on %s", addr)
 	handler := httputil.LimitBody(execution.NewServer(), 0)
-	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("execution", handler)))
+	if err := server.Run(addr, observability.WrapHTTP("execution", handler), 0); err != nil {
+		log.Fatal(err)
+	}
 }
 
 func envOrDefault(key, fallback string) string {

--- a/cmd/fiber-adapter/main.go
+++ b/cmd/fiber-adapter/main.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"log"
-	"net/http"
 	"os"
 	"time"
 
 	"github.com/chenyu/1-tok/internal/fiberadapter"
 	"github.com/chenyu/1-tok/internal/httputil"
+	"github.com/chenyu/1-tok/internal/server"
 	"github.com/chenyu/1-tok/internal/observability"
 )
 
@@ -21,7 +21,9 @@ func main() {
 
 	log.Printf("fiber-adapter listening on %s", addr)
 	handler := httputil.LimitBody(fiberadapter.NewServer(), 0)
-	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("fiber-adapter", handler)))
+	if err := server.Run(addr, observability.WrapHTTP("fiber-adapter", handler), 0); err != nil {
+		log.Fatal(err)
+	}
 }
 
 func envOrDefault(key, fallback string) string {

--- a/cmd/iam/main.go
+++ b/cmd/iam/main.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"log"
-	"net/http"
 	"os"
 	"time"
 
 	"github.com/chenyu/1-tok/internal/httputil"
+	"github.com/chenyu/1-tok/internal/server"
 	"github.com/chenyu/1-tok/internal/observability"
 	"github.com/chenyu/1-tok/internal/services/iam"
 )
@@ -21,7 +21,9 @@ func main() {
 
 	log.Printf("iam listening on %s", addr)
 	handler := httputil.LimitBody(iam.NewServer(), 0)
-	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("iam", handler)))
+	if err := server.Run(addr, observability.WrapHTTP("iam", handler), 0); err != nil {
+		log.Fatal(err)
+	}
 }
 
 func envOrDefault(key, fallback string) string {

--- a/cmd/marketplace/main.go
+++ b/cmd/marketplace/main.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"log"
-	"net/http"
 	"os"
 	"time"
 
 	"github.com/chenyu/1-tok/internal/httputil"
+	"github.com/chenyu/1-tok/internal/server"
 	"github.com/chenyu/1-tok/internal/observability"
 	"github.com/chenyu/1-tok/internal/services/marketplace"
 )
@@ -21,7 +21,9 @@ func main() {
 
 	log.Printf("marketplace listening on %s", addr)
 	handler := httputil.LimitBody(marketplace.NewServer(), 0)
-	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("marketplace", handler)))
+	if err := server.Run(addr, observability.WrapHTTP("marketplace", handler), 0); err != nil {
+		log.Fatal(err)
+	}
 }
 
 func envOrDefault(key, fallback string) string {

--- a/cmd/notification/main.go
+++ b/cmd/notification/main.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"log"
-	"net/http"
 	"os"
 	"time"
 
 	"github.com/chenyu/1-tok/internal/httputil"
+	"github.com/chenyu/1-tok/internal/server"
 	"github.com/chenyu/1-tok/internal/observability"
 	"github.com/chenyu/1-tok/internal/services/notification"
 )
@@ -21,7 +21,9 @@ func main() {
 
 	log.Printf("notification listening on %s", addr)
 	handler := httputil.LimitBody(notification.NewServer(), 0)
-	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("notification", handler)))
+	if err := server.Run(addr, observability.WrapHTTP("notification", handler), 0); err != nil {
+		log.Fatal(err)
+	}
 }
 
 func envOrDefault(key, fallback string) string {

--- a/cmd/risk/main.go
+++ b/cmd/risk/main.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"log"
-	"net/http"
 	"os"
 	"time"
 
 	"github.com/chenyu/1-tok/internal/httputil"
+	"github.com/chenyu/1-tok/internal/server"
 	"github.com/chenyu/1-tok/internal/observability"
 	"github.com/chenyu/1-tok/internal/services/risk"
 )
@@ -21,7 +21,9 @@ func main() {
 
 	log.Printf("risk listening on %s", addr)
 	handler := httputil.LimitBody(risk.NewServer(), 0)
-	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("risk", handler)))
+	if err := server.Run(addr, observability.WrapHTTP("risk", handler), 0); err != nil {
+		log.Fatal(err)
+	}
 }
 
 func envOrDefault(key, fallback string) string {

--- a/cmd/settlement/main.go
+++ b/cmd/settlement/main.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"log"
-	"net/http"
 	"os"
 	"time"
 
 	"github.com/chenyu/1-tok/internal/httputil"
+	"github.com/chenyu/1-tok/internal/server"
 	"github.com/chenyu/1-tok/internal/observability"
 	"github.com/chenyu/1-tok/internal/services/settlement"
 )
@@ -21,7 +21,9 @@ func main() {
 
 	log.Printf("settlement listening on %s", addr)
 	handler := httputil.LimitBody(settlement.NewServer(), 0)
-	log.Fatal(http.ListenAndServe(addr, observability.WrapHTTP("settlement", handler)))
+	if err := server.Run(addr, observability.WrapHTTP("settlement", handler), 0); err != nil {
+		log.Fatal(err)
+	}
 }
 
 func envOrDefault(key, fallback string) string {

--- a/internal/server/run.go
+++ b/internal/server/run.go
@@ -1,0 +1,54 @@
+// Package server provides a shared HTTP server lifecycle with graceful shutdown.
+package server
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+// DefaultDrainTimeout is the maximum time to wait for in-flight requests
+// to complete after receiving a shutdown signal.
+const DefaultDrainTimeout = 15 * time.Second
+
+// Run starts an HTTP server on addr and blocks until a SIGINT or SIGTERM is
+// received. In-flight requests are given up to drainTimeout to complete.
+// Pass 0 for drainTimeout to use DefaultDrainTimeout.
+func Run(addr string, handler http.Handler, drainTimeout time.Duration) error {
+	if drainTimeout <= 0 {
+		drainTimeout = DefaultDrainTimeout
+	}
+
+	srv := &http.Server{
+		Addr:    addr,
+		Handler: handler,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+		}
+		close(errCh)
+	}()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	select {
+	case err := <-errCh:
+		return err
+	case sig := <-sigCh:
+		log.Printf("received %s, draining connections (timeout %s)", sig, drainTimeout)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), drainTimeout)
+	defer cancel()
+
+	return srv.Shutdown(ctx)
+}

--- a/internal/server/run_test.go
+++ b/internal/server/run_test.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"net/http"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestRun_ShutdownOnSIGTERM(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- Run("127.0.0.1:0", handler, 1*time.Second)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	_ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("expected nil error on clean shutdown, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return within 5s after SIGTERM")
+	}
+}


### PR DESCRIPTION
Introduces `internal/server.Run()` which:
- Starts `http.Server` on the given address
- Listens for SIGINT/SIGTERM
- Calls `Shutdown()` with a 15s drain timeout (configurable)
- Returns only after in-flight requests complete or timeout

Replaces raw `http.ListenAndServe` in **8 entrypoints**: api-gateway, settlement, execution, iam, marketplace, notification, risk, fiber-adapter.

Mock services (mock-carrier, mock-fiber, mock-sentry) are unchanged.

Includes test verifying clean shutdown on SIGTERM.

Fixes #30