### PR TITLE
fix(settlement): reconciler loop tolerates transient errors with consecutive error counter

### DIFF
--- a/internal/services/settlement/reconciler.go
+++ b/internal/services/settlement/reconciler.go
@@ -3,6 +3,7 @@ package settlement
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -56,6 +57,10 @@ func (r *Reconciler) Sync(ctx context.Context) (ReconcileSummary, error) {
 	}, nil
 }
 
+// MaxConsecutiveErrors is the number of consecutive sync failures before
+// RunReconcilerLoop gives up and returns an error.
+const MaxConsecutiveErrors = 5
+
 func RunReconcilerLoop(ctx context.Context, reconciler *Reconciler, interval time.Duration, logger *log.Logger) error {
 	if reconciler == nil {
 		return errors.New("reconciler is required")
@@ -76,6 +81,7 @@ func RunReconcilerLoop(ctx context.Context, reconciler *Reconciler, interval tim
 		return nil
 	}
 
+	// First run — fail fast if the initial sync fails.
 	if err := runOnce(); err != nil {
 		return err
 	}
@@ -83,14 +89,21 @@ func RunReconcilerLoop(ctx context.Context, reconciler *Reconciler, interval tim
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
+	consecutiveErrors := 0
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
 			if err := runOnce(); err != nil {
-				return err
+				consecutiveErrors++
+				logger.Printf("settlement reconciler error (%d/%d consecutive): %v", consecutiveErrors, MaxConsecutiveErrors, err)
+				if consecutiveErrors >= MaxConsecutiveErrors {
+					return fmt.Errorf("reconciler exceeded %d consecutive errors, last: %w", MaxConsecutiveErrors, err)
+				}
+				continue
 			}
+			consecutiveErrors = 0
 		}
 	}
 }


### PR DESCRIPTION
Previously, a single Fiber API error (network blip, 503) caused `RunReconcilerLoop` to return immediately, killing the container via `log.Fatal` in `main.go`.

Now the loop:
- Logs each error with a consecutive count
- Continues running after transient failures
- Only gives up after **5 consecutive errors** (`MaxConsecutiveErrors`)
- Resets the counter on any successful sync

First-run failures still fail fast (unchanged).

Fixes #29