### PR TITLE
refactor: replace error string matching with sentinel errors and errors.Is

### DIFF
--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -1,0 +1,10 @@
+package core
+
+import "errors"
+
+var (
+	// ErrOrderNotFound is returned when an order lookup yields no result.
+	ErrOrderNotFound = errors.New("order not found")
+	// ErrMilestoneNotFound is returned when a milestone lookup yields no result.
+	ErrMilestoneNotFound = errors.New("milestone not found")
+)

--- a/internal/core/workflow.go
+++ b/internal/core/workflow.go
@@ -249,7 +249,7 @@ func (o *Order) findMilestone(id string) (*Milestone, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("milestone %s not found", id)
+	return nil, fmt.Errorf("%w: %s", ErrMilestoneNotFound, id)
 }
 
 func (o Order) isLastMilestoneSettled() bool {

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -218,7 +218,7 @@ func (s *Server) handleGetOrder(w http.ResponseWriter, r *http.Request) {
 
 	order, err := s.app.GetOrder(orderID)
 	if err != nil {
-		if err.Error() == "order not found" {
+		if errors.Is(err, core.ErrOrderNotFound) {
 			writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
 			return
 		}
@@ -987,10 +987,12 @@ func writeJSON(w http.ResponseWriter, status int, payload any) {
 }
 
 func writeGatewayError(w http.ResponseWriter, err error) {
-	switch err.Error() {
-	case "order not found":
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
-	case "rfq not found", "bid not found", "dispute not found":
+	switch {
+	case errors.Is(err, core.ErrOrderNotFound),
+		errors.Is(err, core.ErrMilestoneNotFound),
+		errors.Is(err, platform.ErrRFQNotFound),
+		errors.Is(err, platform.ErrBidNotFound),
+		errors.Is(err, platform.ErrDisputeNotFound):
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
 	default:
 		writeJSON(w, http.StatusConflict, map[string]string{"error": err.Error()})

--- a/internal/platform/app.go
+++ b/internal/platform/app.go
@@ -667,7 +667,7 @@ func (r *memoryOrderRepository) Get(id string) (*core.Order, error) {
 	defer r.mu.RUnlock()
 	order, ok := r.data[id]
 	if !ok {
-		return nil, errors.New("order not found")
+		return nil, core.ErrOrderNotFound
 	}
 	return cloneOrder(order), nil
 }
@@ -722,7 +722,7 @@ func (r *memoryRFQRepository) Get(id string) (RFQ, error) {
 			return rfq, nil
 		}
 	}
-	return RFQ{}, errors.New("rfq not found")
+	return RFQ{}, ErrRFQNotFound
 }
 
 func (r *memoryRFQRepository) Save(rfq RFQ) error {
@@ -769,7 +769,7 @@ func (r *memoryBidRepository) Get(id string) (Bid, error) {
 			return cloneBid(bid), nil
 		}
 	}
-	return Bid{}, errors.New("bid not found")
+	return Bid{}, ErrBidNotFound
 }
 
 func (r *memoryBidRepository) Save(bid Bid) error {
@@ -842,7 +842,7 @@ func (r *memoryDisputeRepository) Get(id string) (Dispute, error) {
 			return dispute, nil
 		}
 	}
-	return Dispute{}, errors.New("dispute not found")
+	return Dispute{}, ErrDisputeNotFound
 }
 
 func (r *memoryDisputeRepository) Save(dispute Dispute) error {

--- a/internal/platform/errors.go
+++ b/internal/platform/errors.go
@@ -1,0 +1,16 @@
+package platform
+
+import "errors"
+
+var (
+	// ErrRFQNotFound is returned when an RFQ lookup yields no result.
+	ErrRFQNotFound = errors.New("rfq not found")
+	// ErrBidNotFound is returned when a bid lookup yields no result.
+	ErrBidNotFound = errors.New("bid not found")
+	// ErrDisputeNotFound is returned when a dispute lookup yields no result.
+	ErrDisputeNotFound = errors.New("dispute not found")
+	// ErrMembershipRequired is returned when a user has no qualifying membership.
+	ErrMembershipRequired = errors.New("membership is required")
+	// ErrOrgMismatch is returned when the requested org doesn't match the actor's membership.
+	ErrOrgMismatch = errors.New("organization mismatch")
+)

--- a/internal/store/postgres/repository.go
+++ b/internal/store/postgres/repository.go
@@ -148,7 +148,7 @@ func (r *OrderRepository) Get(id string) (*core.Order, error) {
 	var payload []byte
 	err := r.db.QueryRow(`SELECT payload FROM orders WHERE id = $1`, id).Scan(&payload)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, errors.New("order not found")
+		return nil, core.ErrOrderNotFound
 	}
 	if err != nil {
 		return nil, err
@@ -280,7 +280,7 @@ func scanDispute(row rowScanner) (platform.Dispute, error) {
 		&dispute.CreatedAt,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return platform.Dispute{}, errors.New("dispute not found")
+			return platform.Dispute{}, platform.ErrDisputeNotFound
 		}
 		return platform.Dispute{}, err
 	}
@@ -525,7 +525,7 @@ func scanRFQ(row rowScanner) (platform.RFQ, error) {
 		&rfq.UpdatedAt,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return platform.RFQ{}, errors.New("rfq not found")
+			return platform.RFQ{}, platform.ErrRFQNotFound
 		}
 		return platform.RFQ{}, err
 	}
@@ -615,7 +615,7 @@ func scanBid(row rowScanner) (platform.Bid, error) {
 		&bid.UpdatedAt,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return platform.Bid{}, errors.New("bid not found")
+			return platform.Bid{}, platform.ErrBidNotFound
 		}
 		return platform.Bid{}, err
 	}


### PR DESCRIPTION
Defines sentinel errors in `core` and `platform` packages:

**`internal/core/errors.go`:**
- `ErrOrderNotFound`
- `ErrMilestoneNotFound`

**`internal/platform/errors.go`:**
- `ErrRFQNotFound`, `ErrBidNotFound`, `ErrDisputeNotFound`
- `ErrMembershipRequired`, `ErrOrgMismatch`

Updates all repository implementations (postgres + memory) to return sentinels instead of `errors.New("...")`.

Updates gateway:
- `handleGetOrder`: `errors.Is(err, core.ErrOrderNotFound)`
- `writeGatewayError`: `errors.Is` switch instead of `err.Error()` string matching

All existing tests pass unchanged.

Fixes #25