### PR TITLE
refactor(proxy): replace panic in NewSingleHost with error return

### DIFF
--- a/internal/services/marketplace/server.go
+++ b/internal/services/marketplace/server.go
@@ -1,6 +1,7 @@
 package marketplace
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -13,11 +14,22 @@ type Server struct {
 }
 
 func NewServer() *Server {
-	return &Server{
-		inner: proxy.NewSingleHost(upstream(), func(req *http.Request) {
-			req.URL.Path = "/api/v1" + req.URL.Path[3:]
-		}),
+	s, err := NewServerE()
+	if err != nil {
+		panic(fmt.Sprintf("marketplace: %v", err))
 	}
+	return s
+}
+
+// NewServerE creates a Server with explicit error handling instead of panic.
+func NewServerE() (*Server, error) {
+	inner, err := proxy.NewSingleHostE(upstream(), func(req *http.Request) {
+		req.URL.Path = "/api/v1" + req.URL.Path[3:]
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marketplace upstream: %w", err)
+	}
+	return &Server{inner: inner}, nil
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/internal/services/notification/server.go
+++ b/internal/services/notification/server.go
@@ -1,6 +1,7 @@
 package notification
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 
@@ -12,11 +13,22 @@ type Server struct {
 }
 
 func NewServer() *Server {
-	return &Server{
-		inner: proxy.NewSingleHost(upstream(), func(req *http.Request) {
-			req.URL.Path = "/api/v1/messages"
-		}),
+	s, err := NewServerE()
+	if err != nil {
+		panic(fmt.Sprintf("notification: %v", err))
 	}
+	return s
+}
+
+// NewServerE creates a Server with explicit error handling instead of panic.
+func NewServerE() (*Server, error) {
+	inner, err := proxy.NewSingleHostE(upstream(), func(req *http.Request) {
+		req.URL.Path = "/api/v1/messages"
+	})
+	if err != nil {
+		return nil, fmt.Errorf("notification upstream: %w", err)
+	}
+	return &Server{inner: inner}, nil
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/internal/services/proxy/proxy.go
+++ b/internal/services/proxy/proxy.go
@@ -1,15 +1,31 @@
 package proxy
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 )
 
+// NewSingleHost creates a reverse proxy that forwards requests to upstream.
+// Deprecated: Use NewSingleHostE for explicit error handling.
 func NewSingleHost(upstream string, rewrite func(*http.Request)) http.Handler {
+	h, err := NewSingleHostE(upstream, rewrite)
+	if err != nil {
+		panic(fmt.Sprintf("proxy: %v", err))
+	}
+	return h
+}
+
+// NewSingleHostE creates a reverse proxy like NewSingleHost but returns an
+// error instead of panicking when the upstream URL is invalid.
+func NewSingleHostE(upstream string, rewrite func(*http.Request)) (http.Handler, error) {
 	target, err := url.Parse(upstream)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("parse upstream URL %q: %w", upstream, err)
+	}
+	if target.Scheme == "" || target.Host == "" {
+		return nil, fmt.Errorf("upstream URL %q must have scheme and host", upstream)
 	}
 
 	proxy := httputil.NewSingleHostReverseProxy(target)
@@ -19,5 +35,5 @@ func NewSingleHost(upstream string, rewrite func(*http.Request)) http.Handler {
 		rewrite(req)
 	}
 
-	return proxy
+	return proxy, nil
 }

--- a/internal/services/proxy/proxy_test.go
+++ b/internal/services/proxy/proxy_test.go
@@ -1,0 +1,46 @@
+package proxy
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestNewSingleHostE_ValidURL(t *testing.T) {
+	h, err := NewSingleHostE("http://localhost:8080", func(r *http.Request) {})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if h == nil {
+		t.Fatal("expected non-nil handler")
+	}
+}
+
+func TestNewSingleHostE_InvalidURL(t *testing.T) {
+	_, err := NewSingleHostE("://bad", func(r *http.Request) {})
+	if err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+}
+
+func TestNewSingleHostE_MissingScheme(t *testing.T) {
+	_, err := NewSingleHostE("localhost:8080", func(r *http.Request) {})
+	if err == nil {
+		t.Fatal("expected error for URL without scheme")
+	}
+}
+
+func TestNewSingleHostE_EmptyHost(t *testing.T) {
+	_, err := NewSingleHostE("http://", func(r *http.Request) {})
+	if err == nil {
+		t.Fatal("expected error for URL without host")
+	}
+}
+
+func TestNewSingleHost_PanicsOnBadURL(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for invalid URL")
+		}
+	}()
+	NewSingleHost("://bad", func(r *http.Request) {})
+}

--- a/internal/services/risk/server.go
+++ b/internal/services/risk/server.go
@@ -1,6 +1,7 @@
 package risk
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -13,11 +14,22 @@ type Server struct {
 }
 
 func NewServer() *Server {
-	return &Server{
-		inner: proxy.NewSingleHost(upstream(), func(req *http.Request) {
-			req.URL.Path = "/api/v1" + req.URL.Path[3:]
-		}),
+	s, err := NewServerE()
+	if err != nil {
+		panic(fmt.Sprintf("risk: %v", err))
 	}
+	return s
+}
+
+// NewServerE creates a Server with explicit error handling instead of panic.
+func NewServerE() (*Server, error) {
+	inner, err := proxy.NewSingleHostE(upstream(), func(req *http.Request) {
+		req.URL.Path = "/api/v1" + req.URL.Path[3:]
+	})
+	if err != nil {
+		return nil, fmt.Errorf("risk upstream: %w", err)
+	}
+	return &Server{inner: inner}, nil
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Add `NewSingleHostE()` that returns `(http.Handler, error)` instead of panicking on invalid upstream URLs. Also validates that the URL has both a scheme and host.

Add `NewServerE()` to marketplace, notification, and risk services that propagate the error cleanly.

Original `NewSingleHost()` and `NewServer()` preserved for backward compatibility — they delegate to the E variants internally.

Settlement server excluded (tracked in #24, has its own panic cleanup scope).

**Tests:** 5 new tests for proxy package — valid URL, invalid URL, missing scheme, empty host, panic behavior.

Fixes #21