### PR TITLE
fix(iam): add password strength and email validation on signup

### DIFF
--- a/internal/identity/validation.go
+++ b/internal/identity/validation.go
@@ -1,0 +1,64 @@
+package identity
+
+import (
+	"errors"
+	"strings"
+	"unicode"
+)
+
+// Password policy constants.
+const MinPasswordLength = 8
+
+// Validation errors.
+var (
+	ErrPasswordTooShort    = errors.New("password must be at least 8 characters")
+	ErrPasswordNeedsLetter = errors.New("password must contain at least one letter")
+	ErrPasswordNeedsDigit  = errors.New("password must contain at least one digit")
+	ErrEmailEmpty          = errors.New("email is required")
+	ErrEmailInvalid        = errors.New("invalid email address")
+)
+
+// ValidatePassword checks minimum strength requirements:
+//   - at least 8 characters
+//   - at least one letter (unicode)
+//   - at least one digit
+func ValidatePassword(password string) error {
+	if len(password) < MinPasswordLength {
+		return ErrPasswordTooShort
+	}
+	var hasLetter, hasDigit bool
+	for _, c := range password {
+		if unicode.IsLetter(c) {
+			hasLetter = true
+		}
+		if unicode.IsDigit(c) {
+			hasDigit = true
+		}
+	}
+	if !hasLetter {
+		return ErrPasswordNeedsLetter
+	}
+	if !hasDigit {
+		return ErrPasswordNeedsDigit
+	}
+	return nil
+}
+
+// ValidateEmail performs basic structural email validation:
+// non-empty, contains exactly one "@" with non-empty local and domain parts,
+// and domain has at least one dot.
+func ValidateEmail(email string) error {
+	trimmed := strings.TrimSpace(email)
+	if trimmed == "" {
+		return ErrEmailEmpty
+	}
+	at := strings.IndexByte(trimmed, '@')
+	if at < 1 || at == len(trimmed)-1 {
+		return ErrEmailInvalid
+	}
+	domain := trimmed[at+1:]
+	if !strings.Contains(domain, ".") {
+		return ErrEmailInvalid
+	}
+	return nil
+}

--- a/internal/identity/validation_test.go
+++ b/internal/identity/validation_test.go
@@ -1,0 +1,57 @@
+package identity
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestValidatePassword(t *testing.T) {
+	tests := []struct {
+		name     string
+		password string
+		wantErr  error
+	}{
+		{"valid", "secret99", nil},
+		{"valid long", "correct horse battery staple 1", nil},
+		{"valid unicode", "пароль12", nil},
+		{"too short", "abc1", ErrPasswordTooShort},
+		{"empty", "", ErrPasswordTooShort},
+		{"seven chars", "abcdef1", ErrPasswordTooShort},
+		{"no digit", "abcdefgh", ErrPasswordNeedsDigit},
+		{"no letter", "12345678", ErrPasswordNeedsLetter},
+		{"exactly eight", "abcdefg1", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePassword(tt.password)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("ValidatePassword(%q) = %v, want %v", tt.password, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateEmail(t *testing.T) {
+	tests := []struct {
+		name    string
+		email   string
+		wantErr error
+	}{
+		{"valid", "user@example.com", nil},
+		{"valid subdomain", "user@mail.example.com", nil},
+		{"empty", "", ErrEmailEmpty},
+		{"spaces only", "   ", ErrEmailEmpty},
+		{"no at", "userexample.com", ErrEmailInvalid},
+		{"no local part", "@example.com", ErrEmailInvalid},
+		{"no domain", "user@", ErrEmailInvalid},
+		{"no dot in domain", "user@localhost", ErrEmailInvalid},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateEmail(tt.email)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("ValidateEmail(%q) = %v, want %v", tt.email, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/services/iam/server.go
+++ b/internal/services/iam/server.go
@@ -124,8 +124,8 @@ func (s *Server) handleSignup(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
 		return
 	}
-	if !validSignupPayload(payload.Email, payload.Password, payload.Name, payload.OrganizationName, payload.OrganizationKind) {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing required fields"})
+	if reason := validSignupPayload(payload.Email, payload.Password, payload.Name, payload.OrganizationName, payload.OrganizationKind); reason != "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": reason})
 		return
 	}
 	r = observability.WithRequestTags(r, observability.RequestTags{
@@ -407,18 +407,24 @@ func loadConfiguredStoreFromEnv() (identity.Store, error) {
 	return postgres.NewIdentityStore(db), nil
 }
 
-func validSignupPayload(email, password, name, organizationName, organizationKind string) bool {
-	if strings.TrimSpace(email) == "" || strings.TrimSpace(password) == "" || strings.TrimSpace(name) == "" {
-		return false
+func validSignupPayload(email, password, name, organizationName, organizationKind string) string {
+	if err := identity.ValidateEmail(email); err != nil {
+		return err.Error()
+	}
+	if err := identity.ValidatePassword(password); err != nil {
+		return err.Error()
+	}
+	if strings.TrimSpace(name) == "" {
+		return "name is required"
 	}
 	if strings.TrimSpace(organizationName) == "" {
-		return false
+		return "organization name is required"
 	}
 	switch strings.TrimSpace(organizationKind) {
 	case "buyer", "provider", "ops":
-		return true
+		return ""
 	default:
-		return false
+		return "invalid organization kind"
 	}
 }
 

--- a/internal/services/iam/server_test.go
+++ b/internal/services/iam/server_test.go
@@ -17,7 +17,7 @@ func TestSignupLoginAndMeRoundTrip(t *testing.T) {
 
 	signupBody := map[string]any{
 		"email":            "owner@example.com",
-		"password":         "correct horse battery staple",
+		"password":         "correct horse battery staple 1",
 		"name":             "Owner One",
 		"organizationName": "Atlas Buyer",
 		"organizationKind": "buyer",
@@ -101,7 +101,7 @@ func TestSignupLoginAndMeRoundTrip(t *testing.T) {
 
 	loginBody := map[string]any{
 		"email":    "owner@example.com",
-		"password": "correct horse battery staple",
+		"password": "correct horse battery staple 1",
 	}
 	loginPayload, _ := json.Marshal(loginBody)
 	loginReq := httptest.NewRequest(http.MethodPost, "/v1/sessions", bytes.NewReader(loginPayload))
@@ -138,7 +138,7 @@ func TestLogoutRevokesSession(t *testing.T) {
 
 	signupBody := map[string]any{
 		"email":            "logout@example.com",
-		"password":         "correct horse battery staple",
+		"password":         "correct horse battery staple 1",
 		"name":             "Logout User",
 		"organizationName": "Logout Buyer",
 		"organizationKind": "buyer",
@@ -185,7 +185,7 @@ func TestSignupAssignsOpsReviewerMembership(t *testing.T) {
 
 	signupBody := map[string]any{
 		"email":            "ops@example.com",
-		"password":         "correct horse battery staple",
+		"password":         "correct horse battery staple 1",
 		"name":             "Ops User",
 		"organizationName": "Treasury Ops",
 		"organizationKind": "ops",
@@ -297,7 +297,7 @@ func TestCreateSessionIsRateLimited(t *testing.T) {
 
 	signupPayload, _ := json.Marshal(map[string]any{
 		"email":            "owner@example.com",
-		"password":         "correct horse battery staple",
+		"password":         "correct horse battery staple 1",
 		"name":             "Owner One",
 		"organizationName": "Atlas Buyer",
 		"organizationKind": "buyer",
@@ -312,7 +312,7 @@ func TestCreateSessionIsRateLimited(t *testing.T) {
 
 	loginPayload, _ := json.Marshal(map[string]any{
 		"email":    "owner@example.com",
-		"password": "correct horse battery staple",
+		"password": "correct horse battery staple 1",
 	})
 	for i := 0; i < 2; i++ {
 		req := httptest.NewRequest(http.MethodPost, "/v1/sessions", bytes.NewReader(loginPayload))


### PR DESCRIPTION
Add `identity.ValidatePassword()` and `identity.ValidateEmail()` to enforce minimum security on signup:

**Password rules:**
- Minimum 8 characters
- At least one letter (unicode-aware)
- At least one digit

**Email rules:**
- Non-empty
- Contains `@` with non-empty local and domain parts
- Domain has at least one dot

Updates `validSignupPayload` to return a descriptive reason string instead of a bare `bool`, so the 400 response tells users exactly what's wrong.

**Tests:** 17 test cases for validation, updated IAM server tests to use compliant passwords.

Fixes #57