### PR TITLE
refactor: deduplicate upstream() helper into runtimeconfig.APIGatewayUpstream

### DIFF
--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -27,3 +27,16 @@ func envBool(key string) bool {
 	required, err := strconv.ParseBool(value)
 	return err == nil && required
 }
+
+// DefaultAPIGatewayUpstream is the default address for the api-gateway service.
+const DefaultAPIGatewayUpstream = "http://127.0.0.1:8080"
+
+// APIGatewayUpstream returns the api-gateway upstream URL from the
+// API_GATEWAY_UPSTREAM environment variable, falling back to
+// DefaultAPIGatewayUpstream.
+func APIGatewayUpstream() string {
+	if value := os.Getenv("API_GATEWAY_UPSTREAM"); value != "" {
+		return value
+	}
+	return DefaultAPIGatewayUpstream
+}

--- a/internal/services/execution/server.go
+++ b/internal/services/execution/server.go
@@ -44,7 +44,7 @@ type carrierEventPayload struct {
 
 func NewServer() *Server {
 	return NewServerWithOptions(Options{
-		APIUpstream: upstream(),
+		APIUpstream: runtimeconfig.APIGatewayUpstream(),
 		Carrier:     carrierclient.NewClientFromEnv(),
 	})
 }
@@ -61,7 +61,7 @@ func NewServerWithOptions(options Options) *Server {
 		if runtimeconfig.RequireExternalDependencies() && strings.TrimSpace(os.Getenv("API_GATEWAY_UPSTREAM")) == "" {
 			panic("API_GATEWAY_UPSTREAM is required when ONE_TOK_REQUIRE_EXTERNALS=true")
 		}
-		options.APIUpstream = upstream()
+		options.APIUpstream = runtimeconfig.APIGatewayUpstream()
 	}
 	if options.Carrier == nil {
 		if runtimeconfig.RequireExternalDependencies() {
@@ -328,9 +328,3 @@ func writeJSON(w http.ResponseWriter, status int, payload any) {
 	_ = json.NewEncoder(w).Encode(payload)
 }
 
-func upstream() string {
-	if value := os.Getenv("API_GATEWAY_UPSTREAM"); value != "" {
-		return value
-	}
-	return "http://127.0.0.1:8080"
-}

--- a/internal/services/marketplace/server.go
+++ b/internal/services/marketplace/server.go
@@ -3,10 +3,10 @@ package marketplace
 import (
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/chenyu/1-tok/internal/services/proxy"
+	"github.com/chenyu/1-tok/internal/runtimeconfig"
 )
 
 type Server struct {
@@ -23,7 +23,7 @@ func NewServer() *Server {
 
 // NewServerE creates a Server with explicit error handling instead of panic.
 func NewServerE() (*Server, error) {
-	inner, err := proxy.NewSingleHostE(upstream(), func(req *http.Request) {
+	inner, err := proxy.NewSingleHostE(runtimeconfig.APIGatewayUpstream(), func(req *http.Request) {
 		req.URL.Path = "/api/v1" + req.URL.Path[3:]
 	})
 	if err != nil {
@@ -50,9 +50,3 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func upstream() string {
-	if value := os.Getenv("API_GATEWAY_UPSTREAM"); value != "" {
-		return value
-	}
-	return "http://127.0.0.1:8080"
-}

--- a/internal/services/notification/server.go
+++ b/internal/services/notification/server.go
@@ -3,9 +3,9 @@ package notification
 import (
 	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/chenyu/1-tok/internal/services/proxy"
+	"github.com/chenyu/1-tok/internal/runtimeconfig"
 )
 
 type Server struct {
@@ -22,7 +22,7 @@ func NewServer() *Server {
 
 // NewServerE creates a Server with explicit error handling instead of panic.
 func NewServerE() (*Server, error) {
-	inner, err := proxy.NewSingleHostE(upstream(), func(req *http.Request) {
+	inner, err := proxy.NewSingleHostE(runtimeconfig.APIGatewayUpstream(), func(req *http.Request) {
 		req.URL.Path = "/api/v1/messages"
 	})
 	if err != nil {
@@ -47,9 +47,3 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	http.NotFound(w, r)
 }
 
-func upstream() string {
-	if value := os.Getenv("API_GATEWAY_UPSTREAM"); value != "" {
-		return value
-	}
-	return "http://127.0.0.1:8080"
-}

--- a/internal/services/risk/server.go
+++ b/internal/services/risk/server.go
@@ -3,10 +3,10 @@ package risk
 import (
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/chenyu/1-tok/internal/services/proxy"
+	"github.com/chenyu/1-tok/internal/runtimeconfig"
 )
 
 type Server struct {
@@ -23,7 +23,7 @@ func NewServer() *Server {
 
 // NewServerE creates a Server with explicit error handling instead of panic.
 func NewServerE() (*Server, error) {
-	inner, err := proxy.NewSingleHostE(upstream(), func(req *http.Request) {
+	inner, err := proxy.NewSingleHostE(runtimeconfig.APIGatewayUpstream(), func(req *http.Request) {
 		req.URL.Path = "/api/v1" + req.URL.Path[3:]
 	})
 	if err != nil {
@@ -48,9 +48,3 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	http.NotFound(w, r)
 }
 
-func upstream() string {
-	if value := os.Getenv("API_GATEWAY_UPSTREAM"); value != "" {
-		return value
-	}
-	return "http://127.0.0.1:8080"
-}

--- a/internal/services/settlement/server.go
+++ b/internal/services/settlement/server.go
@@ -35,7 +35,7 @@ type Options struct {
 
 func NewServer() *Server {
 	return NewServerWithOptions(Options{
-		Upstream: upstream(),
+		Upstream: runtimeconfig.APIGatewayUpstream(),
 		Fiber:    fiberclient.NewClientFromEnv(),
 		Auth:     iamclient.NewClientFromEnv(),
 	})
@@ -46,7 +46,7 @@ func NewServerWithOptions(options Options) *Server {
 		if runtimeconfig.RequireExternalDependencies() && strings.TrimSpace(os.Getenv("API_GATEWAY_UPSTREAM")) == "" {
 			panic("API_GATEWAY_UPSTREAM is required when ONE_TOK_REQUIRE_EXTERNALS=true")
 		}
-		options.Upstream = upstream()
+		options.Upstream = runtimeconfig.APIGatewayUpstream()
 	}
 	if options.Fiber == nil {
 		if runtimeconfig.RequireExternalDependencies() {
@@ -569,9 +569,3 @@ func (s *Server) authorizeInternalRoute(r *http.Request) error {
 	return errors.New("invalid service token")
 }
 
-func upstream() string {
-	if value := os.Getenv("API_GATEWAY_UPSTREAM"); value != "" {
-		return value
-	}
-	return "http://127.0.0.1:8080"
-}


### PR DESCRIPTION
Extract the identical `upstream()` function (duplicated in 5 service packages) into `runtimeconfig.APIGatewayUpstream()`.

Reads `API_GATEWAY_UPSTREAM` env var with fallback to `http://127.0.0.1:8080`.

**Packages updated:** marketplace, notification, risk, execution, settlement

Removes unused `os` imports where `upstream()` was the only consumer.

Fixes #28