### PR TITLE
refactor(settlement): replace panic in loadFundingRecordRepository with error return

### DIFF
--- a/internal/services/settlement/funding.go
+++ b/internal/services/settlement/funding.go
@@ -239,17 +239,30 @@ func (r *postgresFundingRecordRepository) List(filter FundingRecordFilter) ([]Fu
 	return records, rows.Err()
 }
 
+// loadFundingRecordRepository returns a FundingRecordRepository.
+// Deprecated: Use loadFundingRecordRepositoryE for explicit error handling.
 func loadFundingRecordRepository() FundingRecordRepository {
+	repo, err := loadFundingRecordRepositoryE()
+	if err != nil {
+		panic(fmt.Sprintf("settlement funding store: %v", err))
+	}
+	return repo
+}
+
+// loadFundingRecordRepositoryE returns a FundingRecordRepository or an error.
+// When persistence is not required and the configured store fails to open,
+// it falls back to an in-memory implementation.
+func loadFundingRecordRepositoryE() (FundingRecordRepository, error) {
 	repository, err := loadConfiguredFundingRecordRepository()
 	if err != nil {
 		if runtimeconfig.RequirePersistence() {
-			panic(err)
+			return nil, err
 		}
 		log.Printf("settlement funding store: falling back to memory: %v", err)
-		return NewMemoryFundingRecordRepository()
+		return NewMemoryFundingRecordRepository(), nil
 	}
 
-	return repository
+	return repository, nil
 }
 
 func loadConfiguredFundingRecordRepository() (FundingRecordRepository, error) {

--- a/internal/services/settlement/reconciler.go
+++ b/internal/services/settlement/reconciler.go
@@ -31,7 +31,11 @@ func NewReconciler(options ReconcilerOptions) *Reconciler {
 		options.Fiber = fiberclient.NewClientFromEnv()
 	}
 	if options.Funding == nil {
-		options.Funding = loadFundingRecordRepository()
+		funding, err := loadFundingRecordRepositoryE()
+		if err != nil {
+			panic(fmt.Sprintf("reconciler: funding store: %v", err))
+		}
+		options.Funding = funding
 	}
 
 	return &Reconciler{

--- a/internal/services/settlement/server.go
+++ b/internal/services/settlement/server.go
@@ -3,6 +3,7 @@ package settlement
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"strconv"
@@ -63,7 +64,11 @@ func NewServerWithOptions(options Options) *Server {
 		options.Fiber = fiberclient.NewClientFromEnv()
 	}
 	if options.Funding == nil {
-		options.Funding = loadFundingRecordRepository()
+		funding, err := loadFundingRecordRepositoryE()
+		if err != nil {
+			panic(fmt.Sprintf("settlement: funding store: %v", err))
+		}
+		options.Funding = funding
 	}
 	if options.Auth == nil {
 		options.Auth = iamclient.NewClientFromEnv()


### PR DESCRIPTION
Add `loadFundingRecordRepositoryE()` returning `(FundingRecordRepository, error)` instead of panicking.

Both callers (server.go, reconciler.go) updated to use the E variant. Stepping stone toward full error returns in #24.

Fixes #26