### PR TITLE
refactor(identity): make DefaultMembershipRoleForOrganizationKind explicit for all org kinds

### DIFF
--- a/internal/identity/roles.go
+++ b/internal/identity/roles.go
@@ -2,8 +2,16 @@ package identity
 
 import "strings"
 
+// DefaultMembershipRoleForOrganizationKind returns the membership role
+// assigned to the founding user of an organization. Every supported
+// organization kind has an explicit mapping so that adding a new kind
+// without defining its default role is a conscious decision.
 func DefaultMembershipRoleForOrganizationKind(kind string) string {
 	switch strings.TrimSpace(kind) {
+	case "buyer":
+		return "org_owner"
+	case "provider":
+		return "org_owner"
 	case "ops":
 		return "ops_reviewer"
 	default:

--- a/internal/identity/roles_test.go
+++ b/internal/identity/roles_test.go
@@ -1,0 +1,25 @@
+package identity
+
+import "testing"
+
+func TestDefaultMembershipRoleForOrganizationKind(t *testing.T) {
+	tests := []struct {
+		kind     string
+		wantRole string
+	}{
+		{"buyer", "org_owner"},
+		{"provider", "org_owner"},
+		{"ops", "ops_reviewer"},
+		{"  ops  ", "ops_reviewer"},
+		{"unknown", "org_owner"},
+		{"", "org_owner"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			got := DefaultMembershipRoleForOrganizationKind(tt.kind)
+			if got != tt.wantRole {
+				t.Errorf("DefaultMembershipRoleForOrganizationKind(%q) = %q, want %q", tt.kind, got, tt.wantRole)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add explicit case arms for `buyer` and `provider` (both → `org_owner`) alongside the existing `ops` → `ops_reviewer` mapping. Default fallback remains `org_owner`.

6 test cases covering all known kinds, whitespace trimming, and unknown/empty inputs.

Fixes #40