### PR TITLE
refactor(iam): NewClientFromEnv returns NoopClient instead of nil

### DIFF
--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -84,7 +84,7 @@ func NewServerWithOptionsE(options Options) (*Server, error) {
 		}
 	}
 	if runtimeconfig.RequireExternalDependencies() {
-		if options.IAM == nil {
+		if options.IAM == nil || iamclient.IsNoop(options.IAM) {
 			return nil, ErrIAMUpstreamRequired
 		}
 		if options.ExecutionTokens.Empty() {
@@ -546,7 +546,7 @@ func (s *Server) handleAwardRFQ(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) resolveBuyerOrg(r *http.Request, requestedBuyerOrgID string) (string, error) {
-	if s.auth == nil {
+	if s.auth == nil || iamclient.IsNoop(s.auth) {
 		return requestedBuyerOrgID, nil
 	}
 
@@ -577,7 +577,7 @@ func (s *Server) resolveBuyerOrg(r *http.Request, requestedBuyerOrgID string) (s
 }
 
 func (s *Server) resolveProviderOrg(r *http.Request, requestedProviderOrgID string) (string, error) {
-	if s.auth == nil {
+	if s.auth == nil || iamclient.IsNoop(s.auth) {
 		return requestedProviderOrgID, nil
 	}
 
@@ -643,7 +643,7 @@ func isOpsRole(role string) bool {
 }
 
 func (s *Server) resolveOpsUser(r *http.Request) (string, error) {
-	if s.auth == nil {
+	if s.auth == nil || iamclient.IsNoop(s.auth) {
 		return "", nil
 	}
 
@@ -666,7 +666,7 @@ func (s *Server) resolveOpsUser(r *http.Request) (string, error) {
 }
 
 func (s *Server) authenticatedActor(r *http.Request) (iamclient.Actor, error) {
-	if s.auth == nil {
+	if s.auth == nil || iamclient.IsNoop(s.auth) {
 		return iamclient.Actor{}, nil
 	}
 
@@ -1030,7 +1030,7 @@ func writeAuthError(w http.ResponseWriter, err error) {
 }
 
 func (s *Server) actorUserID(r *http.Request) string {
-	if s.auth == nil {
+	if s.auth == nil || iamclient.IsNoop(s.auth) {
 		return ""
 	}
 	actor, err := s.authenticatedActor(r)

--- a/internal/integrations/iam/client.go
+++ b/internal/integrations/iam/client.go
@@ -49,9 +49,24 @@ func NewClient(baseURL string) *HTTPClient {
 func NewClientFromEnv() Client {
 	baseURL := strings.TrimSpace(os.Getenv("IAM_UPSTREAM"))
 	if baseURL == "" {
-		return nil
+		return NoopClient{}
 	}
 	return NewClient(baseURL)
+}
+
+// NoopClient is a Client that always returns ErrNotConfigured.
+// It replaces the previous pattern of returning nil, which caused
+// nil-pointer panics in callers that forgot to check.
+type NoopClient struct{}
+
+func (NoopClient) GetActor(_ context.Context, _ string) (Actor, error) {
+	return Actor{}, ErrNotConfigured
+}
+
+// IsNoop reports whether c is a NoopClient (i.e., IAM is not configured).
+func IsNoop(c Client) bool {
+	_, ok := c.(NoopClient)
+	return ok
 }
 
 func (c *HTTPClient) GetActor(ctx context.Context, bearerToken string) (Actor, error) {

--- a/internal/services/settlement/server.go
+++ b/internal/services/settlement/server.go
@@ -76,7 +76,7 @@ func NewServerWithOptions(options Options) *Server {
 		}
 	}
 	if runtimeconfig.RequireExternalDependencies() {
-		if options.Auth == nil {
+		if options.Auth == nil || iamclient.IsNoop(options.Auth) {
 			panic("IAM_UPSTREAM is required when ONE_TOK_REQUIRE_EXTERNALS=true")
 		}
 		if options.ServiceTokens.Empty() {
@@ -446,7 +446,7 @@ func parseWithdrawalRequest(r *http.Request) (withdrawalRequest, error) {
 }
 
 func (s *Server) scopeFundingFilter(r *http.Request, filter *FundingRecordFilter) error {
-	if s.auth == nil {
+	if s.auth == nil || iamclient.IsNoop(s.auth) {
 		return nil
 	}
 
@@ -503,7 +503,7 @@ func isOpsRole(role string) bool {
 }
 
 func (s *Server) resolveProviderOrg(r *http.Request, requestedProviderOrgID string) (string, error) {
-	if s.auth == nil {
+	if s.auth == nil || iamclient.IsNoop(s.auth) {
 		return requestedProviderOrgID, nil
 	}
 


### PR DESCRIPTION
Replace the nil-returning pattern in `NewClientFromEnv` with a `NoopClient` that safely returns `ErrNotConfigured` from `GetActor()`. Prevents nil-pointer panics when callers forget to check.

Adds `IsNoop()` helper for `RequireExternalDependencies` checks and auth-skip paths.

Updates gateway and settlement to use `IsNoop()` alongside nil checks.

Fixes #35