### PR TITLE
fix: [P2] monetary precision, CORS, NATS reconnect, DB indexes, route safety

### DIFF
--- a/cmd/api-gateway/main.go
+++ b/cmd/api-gateway/main.go
@@ -37,7 +37,8 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	handler := httputil.LimitBody(gw, 0)
+	corsOrigin := envOrDefault("CORS_ALLOWED_ORIGIN", "*")
+	handler := httputil.CORS(corsOrigin, httputil.LimitBody(gw, 0))
 	if err := server.Run(addr, observability.WrapHTTP("api-gateway", handler), 0); err != nil {
 		log.Fatal(err)
 	}

--- a/internal/events/nats/publisher.go
+++ b/internal/events/nats/publisher.go
@@ -3,6 +3,7 @@ package nats
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"time"
 
 	"github.com/nats-io/nats.go"
@@ -15,7 +16,19 @@ type Publisher struct {
 }
 
 func Connect(url string) (*Publisher, error) {
-	conn, err := nats.Connect(url)
+	conn, err := nats.Connect(url,
+		nats.MaxReconnects(-1),              // unlimited reconnect attempts
+		nats.ReconnectWait(2*time.Second),   // wait 2s between attempts
+		nats.ReconnectBufSize(16*1024*1024), // buffer up to 16MB while disconnected
+		nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
+			if err != nil {
+				log.Printf("nats: disconnected: %v", err)
+			}
+		}),
+		nats.ReconnectHandler(func(nc *nats.Conn) {
+			log.Printf("nats: reconnected to %s", nc.ConnectedUrl())
+		}),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -112,27 +112,27 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.handleListRFQs(w, r)
 	case r.Method == http.MethodGet && r.URL.Path == "/api/v1/disputes":
 		s.handleListDisputes(w, r)
-	case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/bids"):
+	case r.Method == http.MethodGet && isRFQBidsPath(r.URL.Path):
 		s.handleListRFQBids(w, r)
 	case r.Method == http.MethodGet && r.URL.Path == "/api/v1/orders":
 		s.handleListOrders(w, r)
 	case r.Method == http.MethodPost && r.URL.Path == "/api/v1/rfqs":
 		s.handleCreateRFQ(w, r)
-	case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/bids"):
+	case r.Method == http.MethodPost && isRFQBidsPath(r.URL.Path):
 		s.handleCreateBid(w, r)
-	case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/award"):
+	case r.Method == http.MethodPost && isRFQAwardPath(r.URL.Path):
 		s.handleAwardRFQ(w, r)
 	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/v1/orders/"):
 		s.handleGetOrder(w, r)
 	case r.Method == http.MethodPost && r.URL.Path == "/api/v1/orders":
 		s.handleCreateOrder(w, r)
-	case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/settle"):
+	case r.Method == http.MethodPost && isOrderSettlePath(r.URL.Path):
 		s.handleSettleMilestone(w, r)
-	case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/usage"):
+	case r.Method == http.MethodPost && isOrderUsagePath(r.URL.Path):
 		s.handleRecordUsage(w, r)
-	case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/disputes"):
+	case r.Method == http.MethodPost && isOrderDisputesPath(r.URL.Path):
 		s.handleCreateDispute(w, r)
-	case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/resolve"):
+	case r.Method == http.MethodPost && isDisputeResolvePath(r.URL.Path):
 		s.handleResolveDispute(w, r)
 	case r.Method == http.MethodPost && r.URL.Path == "/api/v1/credits/decision":
 		s.handleCreditDecision(w, r)
@@ -1204,4 +1204,37 @@ func filterBidsForActor(rfq platform.RFQ, bids []platform.Bid, actor iamclient.A
 	}
 
 	return filtered, nil
+}
+
+// Route predicates — used in ServeHTTP to avoid fragile HasSuffix matching.
+// Each function validates that the path matches the expected structure.
+
+func isRFQBidsPath(path string) bool {
+	_, err := rfqIDFromBidsPath(path)
+	return err == nil
+}
+
+func isRFQAwardPath(path string) bool {
+	_, err := rfqIDFromAwardPath(path)
+	return err == nil
+}
+
+func isOrderSettlePath(path string) bool {
+	_, _, err := orderMilestoneFromSettlePath(path)
+	return err == nil
+}
+
+func isOrderUsagePath(path string) bool {
+	_, _, err := orderMilestoneFromUsagePath(path)
+	return err == nil
+}
+
+func isOrderDisputesPath(path string) bool {
+	_, err := orderIDFromDisputePath(path)
+	return err == nil
+}
+
+func isDisputeResolvePath(path string) bool {
+	_, err := disputeIDFromResolvePath(path)
+	return err == nil
 }

--- a/internal/httputil/cors.go
+++ b/internal/httputil/cors.go
@@ -1,0 +1,25 @@
+package httputil
+
+import "net/http"
+
+// CORS wraps handler with permissive CORS headers suitable for API servers
+// that serve a known web frontend. In production, AllowedOrigin should be
+// narrowed to the actual portal domain.
+func CORS(allowedOrigin string, next http.Handler) http.Handler {
+	if allowedOrigin == "" {
+		allowedOrigin = "*"
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", allowedOrigin)
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Accept, Authorization, Content-Type")
+		w.Header().Set("Access-Control-Max-Age", "86400")
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/httputil/cors_test.go
+++ b/internal/httputil/cors_test.go
@@ -1,0 +1,51 @@
+package httputil
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCORS_SetsHeaders(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := CORS("https://portal.example.com", inner)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/orders", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Header().Get("Access-Control-Allow-Origin") != "https://portal.example.com" {
+		t.Errorf("unexpected origin: %s", rec.Header().Get("Access-Control-Allow-Origin"))
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestCORS_PreflightReturns204(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("inner handler should not be called for preflight")
+	})
+
+	handler := CORS("*", inner)
+	req := httptest.NewRequest(http.MethodOptions, "/api/v1/orders", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d", rec.Code)
+	}
+}
+
+func TestCORS_DefaultsToWildcard(t *testing.T) {
+	handler := CORS("", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Errorf("expected wildcard, got %s", rec.Header().Get("Access-Control-Allow-Origin"))
+	}
+}

--- a/internal/services/settlement/funding.go
+++ b/internal/services/settlement/funding.go
@@ -292,7 +292,7 @@ func MigrateFundingRecordStore(db *sql.DB) error {
 			buyer_org_id TEXT,
 			provider_org_id TEXT,
 			asset TEXT NOT NULL,
-			amount TEXT NOT NULL,
+			amount NUMERIC NOT NULL DEFAULT 0,
 			invoice TEXT,
 			external_id TEXT,
 			state TEXT NOT NULL,
@@ -304,6 +304,24 @@ func MigrateFundingRecordStore(db *sql.DB) error {
 			ON settlement_funding_records (invoice) WHERE invoice IS NOT NULL;
 		CREATE UNIQUE INDEX IF NOT EXISTS settlement_funding_records_external_id_uidx
 			ON settlement_funding_records (external_id) WHERE external_id IS NOT NULL;
+
+		-- Migrate: convert amount from TEXT to NUMERIC if needed (idempotent)
+		DO $$ BEGIN
+			IF EXISTS (
+				SELECT 1 FROM information_schema.columns
+				WHERE table_name = 'settlement_funding_records'
+				AND column_name = 'amount'
+				AND data_type = 'text'
+			) THEN
+				ALTER TABLE settlement_funding_records
+					ALTER COLUMN amount TYPE NUMERIC USING amount::numeric;
+			END IF;
+		END $$;
+
+		-- Indexes on filter columns (#65)
+		CREATE INDEX IF NOT EXISTS idx_sfr_order_id ON settlement_funding_records (order_id);
+		CREATE INDEX IF NOT EXISTS idx_sfr_state ON settlement_funding_records (state);
+		CREATE INDEX IF NOT EXISTS idx_sfr_kind ON settlement_funding_records (kind);
 	`)
 	return err
 }

--- a/internal/store/postgres/schema.sql
+++ b/internal/store/postgres/schema.sql
@@ -142,3 +142,19 @@ ALTER TABLE disputes
 
 ALTER TABLE disputes
   ADD COLUMN IF NOT EXISTS resolved_at TIMESTAMPTZ;
+
+-- Indexes on foreign keys and common filter columns (#65)
+CREATE INDEX IF NOT EXISTS idx_memberships_org_id ON memberships (organization_id);
+CREATE INDEX IF NOT EXISTS idx_iam_sessions_user_id ON iam_sessions (user_id);
+CREATE INDEX IF NOT EXISTS idx_iam_sessions_expires_at ON iam_sessions (expires_at) WHERE revoked_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_listings_provider_org_id ON listings (provider_org_id);
+CREATE INDEX IF NOT EXISTS idx_orders_buyer_org_id ON orders (buyer_org_id);
+CREATE INDEX IF NOT EXISTS idx_orders_provider_org_id ON orders (provider_org_id);
+CREATE INDEX IF NOT EXISTS idx_orders_status ON orders (status);
+CREATE INDEX IF NOT EXISTS idx_rfqs_buyer_org_id ON rfqs (buyer_org_id);
+CREATE INDEX IF NOT EXISTS idx_rfqs_status ON rfqs (status);
+CREATE INDEX IF NOT EXISTS idx_bids_rfq_id ON bids (rfq_id);
+CREATE INDEX IF NOT EXISTS idx_bids_provider_org_id ON bids (provider_org_id);
+CREATE INDEX IF NOT EXISTS idx_messages_order_id ON messages (order_id);
+CREATE INDEX IF NOT EXISTS idx_disputes_order_id ON disputes (order_id);
+CREATE INDEX IF NOT EXISTS idx_disputes_status ON disputes (status);


### PR DESCRIPTION
## Five P2 fixes in one batch

### 1. Monetary amounts: TEXT → NUMERIC (#62)
Settlement funding records `amount` column changed from `TEXT` to `NUMERIC`. Includes idempotent migration for existing tables.

### 2. CORS middleware (#63)
`httputil.CORS()` with configurable origin (`CORS_ALLOWED_ORIGIN` env). OPTIONS preflight → 204. Wired into api-gateway.

### 3. NATS reconnect (#64)
Unlimited reconnect attempts, 2s wait, 16MB buffer, disconnect/reconnect logging.

### 4. Database indexes (#65)
15 indexes on FK and filter columns across all tables.

### 5. Route safety (#66)
Replace `strings.HasSuffix` route matching with typed predicate functions that validate full path structure.

3 CORS tests included. All existing tests pass.

Fixes #62
Fixes #63
Fixes #64
Fixes #65
Fixes #66