### PR TITLE
chore: extract Bun version into Dockerfile ARG

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,4 +1,6 @@
-FROM oven/bun:1.2.22 AS deps
+ARG BUN_VERSION=1.2.22
+
+FROM oven/bun:${BUN_VERSION} AS deps
 
 WORKDIR /app
 COPY package.json bun.lockb tsconfig.base.json ./
@@ -6,14 +8,14 @@ COPY apps/web/package.json apps/web/package.json
 COPY packages/contracts/package.json packages/contracts/package.json
 RUN bun install --frozen-lockfile
 
-FROM oven/bun:1.2.22 AS builder
+FROM oven/bun:${BUN_VERSION} AS builder
 
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN bun --cwd apps/web build
 
-FROM oven/bun:1.2.22 AS runner
+FROM oven/bun:${BUN_VERSION} AS runner
 
 WORKDIR /app
 ENV NODE_ENV=production


### PR DESCRIPTION
## Summary

Extract `BUN_VERSION=1.2.22` into a single `ARG` at the top of the Dockerfile, referenced by all three stages (deps, builder, runner). Makes version bumps a one-line change.

Addresses NBS from #79 review (Gemini + Keith-CY).

## Changes
- `apps/web/Dockerfile`: `ARG BUN_VERSION=1.2.22`, `FROM oven/bun:${BUN_VERSION}`