### PR TITLE
fix(ci): compute Go function coverage in CI report

### DIFF
--- a/scripts/ci/coverage-summary.mjs
+++ b/scripts/ci/coverage-summary.mjs
@@ -20,12 +20,12 @@ export function parseGoCoverageSummary(text) {
   // Parse per-function lines to compute function coverage percentage.
   // Each non-total line from `go tool cover -func` looks like:
   //   package/file.go:line:  FuncName    XX.X%
-  const funcLines = text.split("\n").filter(
-    (line) => line.includes("%") && !line.startsWith("total:"),
-  );
   let coveredFuncs = 0;
   let totalFuncs = 0;
-  for (const line of funcLines) {
+  for (const line of text.split("\n")) {
+    if (line.startsWith("total:")) {
+      continue;
+    }
     const pctMatch = line.match(/([0-9.]+)%\s*$/);
     if (pctMatch) {
       totalFuncs += 1;


### PR DESCRIPTION
## Summary

CI report 里 Go 的 Funcs% 一直显示 `-`，因为 `parseGoCoverageSummary` 把 `funcsPct` 硬编码为 `null`。

`go tool cover -func` 的输出包含每个函数的覆盖率百分比，可以从中统计有覆盖的函数比例。

## Fix

解析 `go tool cover -func` 的每行输出，统计覆盖率 > 0% 的函数占比作为 Funcs%。

## Changes
- `scripts/ci/coverage-summary.mjs`: `parseGoCoverageSummary` 新增函数覆盖率计算