### PR TITLE
docs: refine Carrier upstream integration requirements

### DIFF
--- a/docs/carrier-first-class-design.md
+++ b/docs/carrier-first-class-design.md
@@ -1,6 +1,6 @@
 # Carrier First-Class Agent Provider Design
 
-Last updated: `2026-03-13`
+Last updated: `2026-03-15`
 
 This document is the authoritative design for making `Carrier-backed provider` a first-class provider type in `1-tok`.
 
@@ -178,6 +178,37 @@ The platform must add `ExecutionJob` and `ExecutionAttempt`.
 | `endedAt`          | Attempt end time                               |
 | `resultSummary`    | Summary of the attempt's outcome               |
 
+The platform must also persist `ExecutionEvent` as the append-only callback ledger. Required fields:
+
+| Field | Meaning |
+| --- | --- |
+| `id` | platform identifier |
+| `executionJobId` | owning execution job |
+| `eventId` | unique Carrier event id |
+| `sequence` | monotonic sequence for the execution |
+| `eventType` | canonical event name |
+| `attemptId` | Carrier attempt id if present |
+| `payloadJSON` | normalized payload snapshot |
+| `receivedAt` | platform receive time |
+| `decisionJSON` | callback response returned to Carrier |
+
+Ledger rules:
+
+- replaying the same `eventId` must return the previous `decisionJSON` without mutating job state
+- a different `eventId` with `sequence <= lastSequence` is rejected as replay or reordering
+- a gap where `sequence > lastSequence + 1` is rejected so Carrier redelivers the missing event first
+- ledger persistence and derived `ExecutionJob` mutation happen in one transaction
+
+Execution lifecycle rules are fixed:
+
+1. Awarding or resuming an executable milestone creates or resumes one `ExecutionJob` and snapshots the resolved binding/profile target onto the attempt.
+2. The platform calls Carrier create with an idempotency key derived from `executionJobId` and `attemptNo`; retries reuse that same key until Carrier returns the same `carrierExecutionId`.
+3. The synchronous create response only confirms acceptance; callbacks and status fetch remain the authoritative runtime truth.
+4. `execution.accepted`, `execution.started`, and `execution.heartbeat` advance derived runtime state and refresh `lastHeartbeatAt`.
+5. `usage.reported` can change budget state and may cause the callback response to request `pause`.
+6. `milestone.ready` hands evidence into settlement; `execution.completed` only closes execution bookkeeping.
+7. Retries create a new `ExecutionAttempt` but stay inside the same `ExecutionJob`.
+
 ### 4. Settlement, Risk, And Dispute Integration
 
 Platform rules are fixed:
@@ -268,6 +299,39 @@ Callback behavior is fixed:
 - callbacks are signed with the binding-specific HMAC secret
 - Carrier treats non-2xx or `accepted=false` as delivery failure
 - Carrier retries with exponential backoff for at least 15 minutes
+
+### 5. What The Carrier Project Must Deliver
+
+For Carrier maintainers, the requirement is not "be generally compatible". The requirement is to expose a narrow contract that `1-tok` can treat as stable product infrastructure.
+
+Carrier must deliver all of the following:
+
+- a provider-facing way to mint and rotate a provider-scoped integration token for `1-tok`
+- one stable integration base URL for staging and one for production
+- one stable execution API namespace matching this document, instead of asking `1-tok` to target ad hoc internal routes
+- durable `carrierExecutionId`, `attemptId`, `eventId`, and artifact references that survive retries and process restarts
+- explicit translation from Carrier internal runtime states into the canonical states and failure categories in this document
+- callback signing and replay-safe retry behavior
+- artifact and usage-proof retention strong enough for settlement review and disputes
+- pause, resume, and cancel semantics that are safe even when delivered more than once
+
+Carrier should assume that `1-tok` will build platform logic directly against this contract. If Carrier needs additional fields, looser guarantees, or different state semantics, that mismatch must be resolved in the design before implementation ships.
+
+### 6. Joint Integration Requirements
+
+Carrier and `1-tok` have separate ownership, so successful rollout also requires explicit coordination artifacts from the Carrier side.
+
+Carrier must provide:
+
+- one named maintainer or team owning the `1-tok` integration contract
+- one staging tenant or account that `1-tok` can use for end-to-end testing
+- one sample provider-scoped token for staging, or a documented self-serve token issuance flow
+- one verified `(hostId, agentId, backend, workspaceRoot)` tuple that remains stable during integration
+- one callback signing key flow that supports initial setup and later rotation
+- example success, pause, failure, artifact, and usage-proof payloads for local and CI fixtures
+- a changelog policy for contract changes affecting `1-tok`
+
+The integration should not be considered ready for rollout until both teams can run the same happy-path and failure-path scenarios against Carrier staging without relying on undocumented internal knowledge.
 
 ## Interface Contract
 
@@ -456,6 +520,24 @@ Their role is restricted to:
 
 They are not the authoritative marketplace execution path anymore.
 
+## Platform Compatibility Bridge
+
+`origin/main` already ships a platform-side execution-service bridge. The canonical Carrier contract in this document must coexist with that bridge until migration completes.
+
+| Current platform route | Current behavior | Canonical contract |
+| --- | --- | --- |
+| `GET /v1/carrier/codeagent/health` | platform proxy for health verification | Carrier `GET /api/v1/remote/hosts/:hostId/instances/:agentId/codeagent/health` |
+| `GET /v1/carrier/codeagent/version` | platform proxy for backend/version inspection | Carrier `GET /api/v1/remote/hosts/:hostId/instances/:agentId/codeagent/version` |
+| `POST /v1/carrier/codeagent/run` | platform proxy for emergency probe execution | Carrier `POST /api/v1/remote/hosts/:hostId/instances/:agentId/codeagent/run` |
+| `POST /v1/carrier/events` | legacy callback ingress using snake_case event names | Platform `POST /v1/carrier/callbacks/events` using canonical dot-separated event names |
+
+Bridge rules:
+
+- Carrier upstream work targets the canonical endpoints, not the legacy bridge names
+- the platform bridge may temporarily accept snake_case aliases such as `usage_reported`, `budget_low`, and `milestone_ready`, but it normalizes them to canonical names before persistence
+- new smoke tests, docs, and operator runbooks must prefer `/v1/carrier/callbacks/events` and canonical dot-separated event names
+- the legacy callback alias is removable only after ops tooling and smoke coverage no longer depend on it
+
 ## State Mapping
 
 Carrier-to-platform state mapping is fixed:
@@ -498,13 +580,14 @@ Retention defaults:
 
 Implementation order is fixed:
 
-1. Add `CarrierBinding` and `ExecutionProfile` to the platform.
-2. Implement provider-scoped binding verification.
-3. Add async execution endpoints in Carrier.
-4. Add `ExecutionJob`, callback verification, and reconciliation in the platform.
-5. Move listings and bids to reference `executionProfileId`.
-6. Keep existing probe endpoints for diagnostics and fallback.
-7. Rewrite smoke tests so formal marketplace execution uses the async path.
+1. Add `CarrierBinding`, `ExecutionProfile`, `ExecutionJob`, `ExecutionAttempt`, and `ExecutionEvent` to the platform.
+2. Keep the execution-service bridge in place, but add the canonical callback path and dot-separated event normalization.
+3. Implement provider-scoped binding verification.
+4. Add async execution endpoints in Carrier.
+5. Add callback verification, ledger persistence, and stale-job reconciliation in the platform.
+6. Move listings and bids to reference `executionProfileId`.
+7. Rewrite smoke tests and operator tooling so formal marketplace execution uses the canonical async path and callback names.
+8. Remove the legacy callback alias only after the migration is complete.
 
 ## Acceptance Criteria
 
@@ -513,8 +596,10 @@ The integration is ready when all of these are true:
 - a provider can bind Carrier resources without ops editing database rows
 - a listing or bid cannot be published without an active execution profile
 - an awarded order creates an execution job and receives signed Carrier callbacks
+- execution callbacks are durably ledgered and gap or replay handling is deterministic
 - duplicate and out-of-order callbacks do not corrupt job state
 - a budget overrun pauses execution and later resumes after budget extension
 - a dispute case can show artifact refs and usage proofs from Carrier
 - binding suspension blocks new awards but does not break already-running orders
+- smoke tests and ops tooling no longer depend on `/v1/carrier/events` or snake_case callback names before that alias is removed
 - the upstream Carrier PR can be described entirely by the checklist in [carrier-pr-support.md](./carrier-pr-support.md)

--- a/docs/carrier-pr-support.md
+++ b/docs/carrier-pr-support.md
@@ -14,6 +14,33 @@ That means:
 - each awarded marketplace milestone can become one asynchronous Carrier execution
 - Carrier can push signed lifecycle events and expose durable execution evidence
 
+## What Carrier Developers Need To Build
+
+This checklist is written for the Carrier project, not for `1-tok`.
+
+Carrier developers should read it as a product-integration contract with four concrete outcomes:
+
+1. A provider can safely delegate execution authority from Carrier to `1-tok` without exposing unrelated tenants or resources.
+2. `1-tok` can create, observe, pause, resume, and cancel Carrier executions through a stable API contract.
+3. Carrier can push settlement-grade execution evidence back to `1-tok` in a replay-safe way.
+4. Both teams can run joint staging tests without special-case scripts or manual database edits.
+
+If a planned Carrier implementation does not satisfy one of those outcomes, it is incomplete even if the raw endpoint exists.
+
+## Required Carrier Coordination Artifacts
+
+Carrier needs to provide these non-code deliverables as part of the integration work:
+
+- a stable staging base URL for the `1-tok` integration namespace
+- a documented flow for minting or rotating provider-scoped integration tokens
+- at least one stable staging resource tuple: `hostId`, `agentId`, `backend`, `workspaceRoot`
+- callback signing setup instructions, including how `keyId` and secret rotation work
+- sample callback payloads for success, budget pause, failure, and artifact publication cases
+- sample usage-proof and artifact payloads that match real Carrier behavior
+- a named Carrier owner for contract questions and rollout approvals
+
+These are required because `1-tok` cannot infer Carrier tenancy, signing, or execution semantics by reading the Carrier codebase.
+
 ## Required Carrier Deliverables
 
 ### 1. Keep the existing compatibility probes
@@ -43,6 +70,8 @@ Required endpoints:
 | `GET` | `/api/v1/integrations/one-tok/executions/:id` | fetch authoritative execution state |
 | `POST` | `/api/v1/integrations/one-tok/executions/:id/actions` | pause, resume, or cancel execution |
 
+Carrier should treat this namespace as a versioned public contract for `1-tok`. Avoid coupling `1-tok` to internal-only routes, internal state names, or one-off staging shims.
+
 ### 3. Support provider-scoped bearer tokens
 
 Carrier must support a provider-issued integration token with these properties:
@@ -65,6 +94,15 @@ Required delivery guarantees:
 - retry-safe delivery with the same `eventId`
 - HMAC signing using a binding-specific key and secret
 - exponential retry on transient failure
+
+Callback contract details that should shape the Carrier implementation:
+
+- canonical callback path is `POST /v1/carrier/callbacks/events`
+- canonical event names use dot-separated form such as `usage.reported` and `milestone.ready`
+- the platform may temporarily keep a legacy `/v1/carrier/events` alias with snake_case names for internal bridge traffic, but Carrier upstream work should target the canonical path and names
+- if the platform returns `accepted=false`, Carrier must retry the same `eventId` and `sequence` rather than minting a new event
+- Carrier should expect the platform to reject a sequence gap until the missing earlier event is redelivered
+- when the platform returns `recommendedAction.type=pause` or `cancel`, Carrier should treat it as authoritative control-plane feedback for that execution
 
 Required event types:
 
@@ -100,6 +138,19 @@ Minimum failure categories:
 - `invalid_input`
 - `buyer_dependency_missing`
 - `unknown`
+
+### 6. Honor platform control-plane decisions
+
+Carrier must treat the platform callback response as part of the control plane.
+
+Required behavior:
+
+- if callback response says `recommendedAction.type=continue`, Carrier may keep running
+- if callback response says `recommendedAction.type=pause`, Carrier should pause as soon as safely possible and emit `execution.paused`
+- if callback response says `recommendedAction.type=cancel`, Carrier should cancel as soon as safely possible and emit the matching terminal event
+- if callback response says `accepted=false`, Carrier must retry the same callback delivery rather than assuming the platform observed the event
+
+This prevents budget enforcement and dispute safety from depending on out-of-band operator action.
 
 ## Payload Expectations
 
@@ -165,6 +216,27 @@ The response must include:
 
 The callback secret should be established during binding creation or credential rotation, then referenced by `callbacks.auth.keyId`. It should not be resent on every execution create request.
 
+### Idempotency And Sequencing Expectations
+
+- reusing the same `Idempotency-Key` on `POST /api/v1/integrations/one-tok/executions` must return the same `carrierExecutionId`
+- retries of the same action request must be safe and must not double-apply `pause`, `resume`, or `cancel`
+- replaying one callback delivery must reuse the same `eventId` and `sequence`; a logical retry must not mint a new identity
+- status fetch should converge with the last accepted callback so the platform can reconcile stale jobs deterministically
+
+### Minimum Joint Test Matrix
+
+Carrier should be able to demonstrate all of the following in staging:
+
+- verify one provider resource tuple successfully
+- create one execution and return a durable `carrierExecutionId`
+- emit `execution.accepted`, `execution.started`, `usage.reported`, `milestone.ready`, and `execution.completed`
+- emit `budget.low` or honor a platform `pause` recommendation after usage is reported
+- recover from one callback retry without creating duplicate execution history
+- recover from one out-of-order callback by redelivering the missing earlier event
+- expose at least one artifact reference and one usage proof for a completed execution
+
+If Carrier cannot run this matrix, the integration is not ready for `1-tok` production rollout.
+
 ## Done Criteria For The Carrier PR
 
 The Carrier work is complete when:
@@ -173,8 +245,12 @@ The Carrier work is complete when:
 - `1-tok` can create an async execution for one awarded milestone
 - Carrier can push signed lifecycle events for that execution
 - duplicate or retried callbacks are safe
+- out-of-order callback gaps can be recovered by redelivering the missing event without inventing a new `eventId`
+- Carrier honors platform `pause` or `cancel` recommendations returned from callback responses
 - Carrier can expose logs, output artifacts, and usage proofs by execution id
 - failure states are typed instead of only free-form strings
+- no new Carrier work depends on the platform's legacy `/v1/carrier/events` alias or snake_case event names
+- Carrier has provided the staging artifacts and ownership information listed above so both teams can complete joint integration
 
 ## Explicit Non-Goals For The First PR
 

--- a/docs/carrier-upstream-issue-template-github.md
+++ b/docs/carrier-upstream-issue-template-github.md
@@ -1,0 +1,189 @@
+# GitHub-Ready Carrier Upstream Issue Draft
+
+## Suggested Title
+
+`feat: add first-class 1-tok marketplace integration contract`
+
+## Paste-Ready Issue Body
+
+```md
+## Summary
+
+`1-tok` needs Carrier to expose a stable, provider-scoped integration contract so Carrier-backed providers can participate in the marketplace as first-class providers.
+
+This work is not only about adding endpoints. The Carrier side also needs to support:
+
+- provider-scoped execution authority
+- stable execution identity
+- signed, replay-safe lifecycle callbacks
+- budget-aware control-plane feedback
+- durable artifacts and usage proofs for settlement and disputes
+
+Reference docs from the `1-tok` side:
+
+- `docs/carrier-first-class-design.md`
+- `docs/carrier-pr-support.md`
+
+## Required Outcomes
+
+This integration is complete only when all of the following are true:
+
+1. A provider can delegate execution authority from Carrier to `1-tok` using a provider-scoped token.
+2. `1-tok` can create, observe, pause, resume, and cancel Carrier executions through a stable API contract.
+3. Carrier can push replay-safe lifecycle callbacks and expose durable artifacts and usage proofs.
+4. Both teams can run staging validation without manual DB edits or undocumented internal steps.
+
+## Required Carrier API Surface
+
+### Provider-scoped token
+
+Carrier needs a provider-issued integration token that is:
+
+- scoped to one provider account or tenant
+- limited to that provider's own resources
+- rotatable without hard downtime
+- usable on both probe endpoints and async execution endpoints
+
+### Stable integration namespace
+
+Recommended namespace:
+
+- `/api/v1/integrations/one-tok/*`
+
+Required endpoints:
+
+- `POST /api/v1/integrations/one-tok/bindings/verify`
+- `POST /api/v1/integrations/one-tok/executions`
+- `GET /api/v1/integrations/one-tok/executions/:id`
+- `POST /api/v1/integrations/one-tok/executions/:id/actions`
+
+Existing probe endpoints should remain supported:
+
+- `GET /api/v1/remote/hosts/:hostId/instances/:agentId/codeagent/health`
+- `GET /api/v1/remote/hosts/:hostId/instances/:agentId/codeagent/version`
+- `POST /api/v1/remote/hosts/:hostId/instances/:agentId/codeagent/run`
+
+## Execution And Callback Requirements
+
+Carrier needs to provide durable execution identity and replay-safe delivery:
+
+- stable `carrierExecutionId`
+- stable `attemptId`
+- unique `eventId`
+- monotonic `sequence` per execution
+- idempotent execution create behavior
+- idempotent pause / resume / cancel behavior
+
+Canonical callback target on the `1-tok` side:
+
+- `POST /v1/carrier/callbacks/events`
+
+Canonical event names:
+
+- `execution.accepted`
+- `execution.started`
+- `execution.heartbeat`
+- `milestone.started`
+- `usage.reported`
+- `artifact.ready`
+- `budget.low`
+- `milestone.ready`
+- `execution.pause_requested`
+- `execution.paused`
+- `execution.resumed`
+- `execution.failed`
+- `execution.completed`
+
+Required callback behavior:
+
+- retries must reuse the same `eventId` and `sequence`
+- `accepted=false` must be treated as delivery failure and retried
+- out-of-order gaps should be recoverable by redelivering the missing earlier event
+- callback response `recommendedAction.type=pause` or `cancel` should be treated as authoritative platform feedback
+
+## Evidence Requirements
+
+Carrier needs to expose:
+
+- authoritative execution status
+- typed failure category and failure code
+- artifact references for logs and outputs
+- usage proofs for billable usage events
+
+Minimum failure categories:
+
+- `provider_fault`
+- `policy_denied`
+- `infra_unavailable`
+- `timeout`
+- `invalid_input`
+- `buyer_dependency_missing`
+- `unknown`
+
+## Required Coordination Artifacts
+
+To unblock joint integration, Carrier also needs to provide:
+
+- one stable staging base URL
+- one documented token issuance or rotation flow
+- one stable staging resource tuple:
+  - `hostId`
+  - `agentId`
+  - `backend`
+  - `workspaceRoot`
+- callback signing setup instructions
+- sample callback payloads for success, budget pause, failure, and artifact publication
+- sample usage-proof payloads
+- one named Carrier owner for contract questions and rollout approval
+
+## Minimum Staging Test Matrix
+
+We should be able to demonstrate all of the following in staging:
+
+1. Verify one provider resource tuple successfully.
+2. Create one execution and receive a durable `carrierExecutionId`.
+3. Emit `execution.accepted`, `execution.started`, `usage.reported`, `milestone.ready`, and `execution.completed`.
+4. Honor a platform pause recommendation after budget or usage pressure.
+5. Retry one callback safely without duplicate execution history.
+6. Recover from one out-of-order callback by redelivering the missing earlier event.
+7. Expose at least one artifact reference and one usage proof for a completed execution.
+
+## Acceptance Criteria
+
+- provider-scoped token flow exists and is documented
+- integration namespace exists and is stable
+- create and action endpoints are idempotent
+- callbacks are signed and replay-safe
+- pause / resume / cancel semantics are implemented
+- status, artifacts, and usage proofs are queryable by execution id
+- staging artifacts and ownership information are available for joint testing
+- no new Carrier work depends on the legacy `/v1/carrier/events` alias or snake_case callback names
+
+## Non-Goals
+
+- interactive terminal streaming
+- platform-managed host or agent creation
+- multi-agent DAG orchestration
+- buyer-facing UI work
+- payment settlement logic inside Carrier
+```
+
+## Optional PR Checklist
+
+```md
+## 1-tok Integration Checklist
+
+- [ ] provider-scoped token flow exists
+- [ ] stable `/api/v1/integrations/one-tok/*` namespace added
+- [ ] existing probe endpoints still work
+- [ ] execution create is idempotent
+- [ ] execution actions are idempotent
+- [ ] signed callbacks use canonical dot-separated event names
+- [ ] callback retries preserve `eventId` and `sequence`
+- [ ] platform `pause` / `cancel` recommendations are honored
+- [ ] status endpoint exposes authoritative state
+- [ ] artifact refs are exposed
+- [ ] usage proofs are exposed
+- [ ] staging base URL and sample credentials shared with `1-tok`
+- [ ] sample payloads shared for joint testing
+```

--- a/docs/carrier-upstream-issue-template.md
+++ b/docs/carrier-upstream-issue-template.md
@@ -1,0 +1,204 @@
+# Carrier Integration Upstream Issue / PR Template
+
+Use this template when opening an issue in the Carrier repo, or when drafting the upstream Carrier PR description for the `1-tok` integration.
+
+The goal is to give Carrier maintainers a concrete, implementation-ready request instead of a loose compatibility ask.
+
+## Suggested Issue Title
+
+`feat: add first-class 1-tok marketplace integration contract`
+
+## Issue Body Template
+
+```md
+## Summary
+
+`1-tok` needs Carrier to expose a stable, provider-scoped integration contract so Carrier-backed providers can participate in the marketplace as first-class providers.
+
+This is not only an endpoint request. The Carrier side also needs to support stable execution identity, callback signing, budget-aware control-plane feedback, and dispute-grade execution evidence.
+
+Authoritative design references:
+
+- 1-tok design: `docs/carrier-first-class-design.md`
+- 1-tok upstream checklist: `docs/carrier-pr-support.md`
+
+## Desired Outcomes
+
+This work is complete only when all of these outcomes are true:
+
+1. A provider can safely delegate execution authority from Carrier to `1-tok` using a provider-scoped token.
+2. `1-tok` can create, observe, pause, resume, and cancel Carrier executions through a stable API namespace.
+3. Carrier can push replay-safe lifecycle callbacks and expose durable artifacts and usage proofs.
+4. Both teams can run joint staging tests without manual DB edits or undocumented internal steps.
+
+## Required Carrier Deliverables
+
+### 1. Provider-scoped integration credential
+
+Carrier needs a provider-issued integration token with these properties:
+
+- scoped to one provider account or tenant
+- limited to that provider's own resources
+- rotatable without hard downtime
+- usable on both probe and async execution endpoints
+
+### 2. Stable integration namespace
+
+Recommended namespace:
+
+- `/api/v1/integrations/one-tok/*`
+
+Required endpoints:
+
+- `POST /api/v1/integrations/one-tok/bindings/verify`
+- `POST /api/v1/integrations/one-tok/executions`
+- `GET /api/v1/integrations/one-tok/executions/:id`
+- `POST /api/v1/integrations/one-tok/executions/:id/actions`
+
+Existing compatibility probes should remain supported:
+
+- `GET /api/v1/remote/hosts/:hostId/instances/:agentId/codeagent/health`
+- `GET /api/v1/remote/hosts/:hostId/instances/:agentId/codeagent/version`
+- `POST /api/v1/remote/hosts/:hostId/instances/:agentId/codeagent/run`
+
+### 3. Stable execution identity and sequencing
+
+Carrier needs to provide durable identifiers and replay-safe behavior:
+
+- stable `carrierExecutionId`
+- stable `attemptId`
+- unique `eventId`
+- monotonic `sequence` per execution
+- idempotent handling for execution create and action requests
+
+### 4. Signed callback delivery
+
+Canonical callback target on the `1-tok` side:
+
+- `POST /v1/carrier/callbacks/events`
+
+Canonical event names:
+
+- `execution.accepted`
+- `execution.started`
+- `execution.heartbeat`
+- `milestone.started`
+- `usage.reported`
+- `artifact.ready`
+- `budget.low`
+- `milestone.ready`
+- `execution.pause_requested`
+- `execution.paused`
+- `execution.resumed`
+- `execution.failed`
+- `execution.completed`
+
+Required behavior:
+
+- retries reuse the same `eventId` and `sequence`
+- `accepted=false` means delivery failed and must be retried
+- out-of-order gaps should be recoverable by redelivering the missing earlier event
+- callback response `recommendedAction.type=pause` or `cancel` should be treated as authoritative platform feedback
+
+### 5. Durable evidence
+
+Carrier needs to expose:
+
+- authoritative execution status
+- typed failure category and failure code
+- artifact references for logs and outputs
+- usage proofs for billable usage events
+
+Minimum failure categories:
+
+- `provider_fault`
+- `policy_denied`
+- `infra_unavailable`
+- `timeout`
+- `invalid_input`
+- `buyer_dependency_missing`
+- `unknown`
+
+## Required Coordination Artifacts
+
+Carrier also needs to provide the following to unblock joint integration:
+
+- one stable staging base URL
+- one documented token issuance or rotation flow
+- one stable staging resource tuple:
+  - `hostId`
+  - `agentId`
+  - `backend`
+  - `workspaceRoot`
+- callback signing setup instructions
+- sample callback payloads for success, budget pause, failure, and artifact publication
+- sample usage-proof payloads
+- one named Carrier owner for contract questions and rollout approval
+
+## Minimum Joint Test Matrix
+
+We should be able to demonstrate all of the following in staging:
+
+1. Verify one provider resource tuple successfully.
+2. Create one execution and receive a durable `carrierExecutionId`.
+3. Emit `execution.accepted`, `execution.started`, `usage.reported`, `milestone.ready`, and `execution.completed`.
+4. Honor a platform pause recommendation after budget or usage pressure.
+5. Retry one callback safely without duplicate execution history.
+6. Recover from one out-of-order callback by redelivering the missing earlier event.
+7. Expose at least one artifact reference and one usage proof for a completed execution.
+
+## Acceptance Criteria
+
+- provider-scoped token flow exists and is documented
+- integration namespace exists and is stable
+- create and action endpoints are idempotent
+- callbacks are signed and replay-safe
+- pause/resume/cancel semantics are implemented
+- status, artifacts, and usage proofs are queryable by execution id
+- staging artifacts and ownership information are available for joint testing
+- no new Carrier work depends on the legacy `/v1/carrier/events` alias or snake_case callback names
+
+## Explicit Non-Goals
+
+- interactive terminal streaming
+- platform-managed host or agent creation
+- multi-agent DAG orchestration
+- buyer-facing UI work
+- payment settlement logic inside Carrier
+
+## Open Questions
+
+- Does Carrier already have a public token issuance flow that matches the provider-scoped model, or does this need new surface area?
+- Which Carrier internal state machine should map to the canonical execution states in the `1-tok` design?
+- What is the intended retention window for artifacts and usage proofs in staging vs production?
+```
+
+## Suggested PR Description Addendum
+
+If Carrier maintainers prefer to open a PR directly, append this checklist to the PR body:
+
+```md
+## 1-tok Integration Checklist
+
+- [ ] provider-scoped token flow exists
+- [ ] stable `/api/v1/integrations/one-tok/*` namespace added
+- [ ] existing probe endpoints still work
+- [ ] execution create is idempotent
+- [ ] execution actions are idempotent
+- [ ] signed callbacks use canonical dot-separated event names
+- [ ] callback retries preserve `eventId` and `sequence`
+- [ ] platform `pause` / `cancel` recommendations are honored
+- [ ] status endpoint exposes authoritative state
+- [ ] artifact refs are exposed
+- [ ] usage proofs are exposed
+- [ ] staging base URL and sample credentials shared with 1-tok
+- [ ] sample payloads shared for joint testing
+```
+
+## Notes For The 1-tok Side
+
+When sending this upstream:
+
+- link the two authoritative docs instead of pasting large excerpts
+- keep the issue focused on contract and rollout expectations, not on `1-tok` internal implementation details
+- ask Carrier maintainers to call out any mismatch in sequencing, retention, or control-plane semantics before implementation starts


### PR DESCRIPTION
## Summary
- tighten the Carrier first-class design with callback ledger, sequencing, and migration bridge requirements
- expand Carrier-facing requirements so Carrier developers know the API, control-plane, and evidence expectations
- add upstream issue templates for opening a Carrier repo issue or PR

## Test Plan
- not run (docs-only changes)